### PR TITLE
Trailing space and rfc include fix

### DIFF
--- a/draft-ietf-anima-brski-async-enroll.xml
+++ b/draft-ietf-anima-brski-async-enroll.xml
@@ -53,7 +53,7 @@
 		<uri>https://www.siemens.com/</uri>
       </address>
     </author>
-	
+
 	<author initials="E." surname="Lear" fullname="Eliot Lear">
       <organization>Cisco Systems</organization>
       <address>
@@ -91,18 +91,18 @@
 
     <abstract>
       <t> This document describes enhancements of bootstrapping a remote secure
-          key infrastructure (BRSKI, <xref target="RFC8995" /> ) to also operate 
-		  in domains featuring no or only timely limited connectivity between 
-		  involved components. 
-		  Further enhancements are provided to perform the BRSKI approach 
-		  in environments, in which the role of the pledge changes from a client 
-		  to a server . This changes the interaction model from a 
-		  pledge-initiator-mode to a pledge-responder-mode. To support both 
-		  use cases, BRSKI-AE relies on the exchange of authenticated self-contained 
-		  objects (signature-wrapped objects) also for requesting and 
-		  distributing of domain specific device certificates. 
-          The defined approach is agnostic regarding the utilized enrollment 
-          protocol allowing the application of existing and potentially new 
+          key infrastructure (BRSKI, <xref target="RFC8995" /> ) to also operate
+		  in domains featuring no or only timely limited connectivity between
+		  involved components.
+		  Further enhancements are provided to perform the BRSKI approach
+		  in environments, in which the role of the pledge changes from a client
+		  to a server . This changes the interaction model from a
+		  pledge-initiator-mode to a pledge-responder-mode. To support both
+		  use cases, BRSKI-AE relies on the exchange of authenticated self-contained
+		  objects (signature-wrapped objects) also for requesting and
+		  distributing of domain specific device certificates.
+          The defined approach is agnostic regarding the utilized enrollment
+          protocol allowing the application of existing and potentially new
           certificate management protocols.</t>
     </abstract>
   </front>
@@ -110,194 +110,194 @@
   <middle>
     <section title="Introduction">
       <t>
-        BRSKI as defined in <xref target="RFC8995" /> specifies a solution for 
-		secure zero-touch (automated) bootstrapping of devices (pledges) in a 
-		(customer) site domain. This includes the discovery of network elements 
-		in the target domain, time synchronization, and the exchange of security 
-		information necessary to establish trust between a pledge and the 
-		domain.	Security information about the target domain, specifically the 
-		target domain certificate, is exchanged utilizing voucher objects as 
-		defined in <xref target="RFC8366" />. 
-		These vouchers are authenticated self-contained (signed) objects, which 
-		may be provided online (synchronous) or offline (asynchronous) via the 
-		domain registrar to the pledge and originate from a Manufacturer's 
+        BRSKI as defined in <xref target="RFC8995" /> specifies a solution for
+		secure zero-touch (automated) bootstrapping of devices (pledges) in a
+		(customer) site domain. This includes the discovery of network elements
+		in the target domain, time synchronization, and the exchange of security
+		information necessary to establish trust between a pledge and the
+		domain.	Security information about the target domain, specifically the
+		target domain certificate, is exchanged utilizing voucher objects as
+		defined in <xref target="RFC8366" />.
+		These vouchers are authenticated self-contained (signed) objects, which
+		may be provided online (synchronous) or offline (asynchronous) via the
+		domain registrar to the pledge and originate from a Manufacturer's
 		Authorized Signing Authority (MASA).</t>
 
-      <t> 		
-		For the enrollment of devices BRSKI relies on EST 
-		<xref target="RFC7030" /> to request and distribute target domain 
-		specific device certificates. EST in turn relies on a binding of the 
-		certification request to an underlying TLS connection between the EST 
+      <t>
+		For the enrollment of devices BRSKI relies on EST
+		<xref target="RFC7030" /> to request and distribute target domain
+		specific device certificates. EST in turn relies on a binding of the
+		certification request to an underlying TLS connection between the EST
 		client and the EST server. According to BRSKI the domain registrar acts
-		as EST server and is also acting as registration authority (RA) or 
-		local registration authority (LRA). 
-		The binding to TLS is used to protect the exchange of a certification 
-		request (for a LDevID EE certificate) and to provide data origin 
-		authentication (client identity information), to support the authorization 
-		decision for processing the certification request. The TLS connection 
-		is mutually authenticated and the client-side authentication utilizes 
-		the pledge's manufacturer issued device certificate (IDevID certificate). 
- 	    This approach requires an on-site availability of a local asset or 
-		inventory management system performing the authorization decision based 
-		on tuple of the certification request and the pledge authentication 
-		using the IDevID certificate, to issue a domain specific certificate to 
-		the pledge.	The EST server (the domain registrar) terminates the security 
-		association with the pledge and thus the binding between the 
-		certification request and the authentication of the pledge via TLS.  
-	    This type of enrollment utilizing an online connection to the PKI 
+		as EST server and is also acting as registration authority (RA) or
+		local registration authority (LRA).
+		The binding to TLS is used to protect the exchange of a certification
+		request (for a LDevID EE certificate) and to provide data origin
+		authentication (client identity information), to support the authorization
+		decision for processing the certification request. The TLS connection
+		is mutually authenticated and the client-side authentication utilizes
+		the pledge's manufacturer issued device certificate (IDevID certificate).
+ 	    This approach requires an on-site availability of a local asset or
+		inventory management system performing the authorization decision based
+		on tuple of the certification request and the pledge authentication
+		using the IDevID certificate, to issue a domain specific certificate to
+		the pledge.	The EST server (the domain registrar) terminates the security
+		association with the pledge and thus the binding between the
+		certification request and the authentication of the pledge via TLS.
+	    This type of enrollment utilizing an online connection to the PKI
 		is considered as synchronous enrollment. </t>
 
       <t>
-	    For certain use cases on-site support of a RA/CA component and/or an 
-		asset management is not available and rather provided by an operator's 
-		backend and may be provided timely limited or completely through 
-		offline interactions. 
-		This may be due to higher security requirements for operating the 
-		certification authority or for optimization of operation for smaller 
-		deployments to avoid the always on-site operation. The authorization of 
-		a certification request based on an asset management in this case will 
-		not / can not be performed on-site at enrollment time. Enrollment, 
-		which cannot be performed in a (timely) consistent fashion is considered 
-		as asynchronous enrollment in this document. It requires the support of 
-		a store and forward functionality of certification request together 
-		with the requester authentication (and identity) information. This 
-		enables processing of the request at a later point in time. 
-		A similar situation may occur through network segmentation, which is 
-		utilized in industrial systems to separate domains with different 
-		security needs. Here, a similar requirement arises if the communication 
-		channel carrying the requester authentication is terminated before 
-		the RA/CA authorization handling of the certification request. If a 
-		second communication channel is opened to forward the certification 
-		request to the issuing RA/ CA, the requester authentication information 
-		needs to be retained and ideally bound to the certification request. 
-		This uses case is independent from timely limitations of the first use 
-		case. For both cases, it is assumed that the requester authentication 
-		information is utilized in the process of authorization of a 
+	    For certain use cases on-site support of a RA/CA component and/or an
+		asset management is not available and rather provided by an operator's
+		backend and may be provided timely limited or completely through
+		offline interactions.
+		This may be due to higher security requirements for operating the
+		certification authority or for optimization of operation for smaller
+		deployments to avoid the always on-site operation. The authorization of
+		a certification request based on an asset management in this case will
+		not / can not be performed on-site at enrollment time. Enrollment,
+		which cannot be performed in a (timely) consistent fashion is considered
+		as asynchronous enrollment in this document. It requires the support of
+		a store and forward functionality of certification request together
+		with the requester authentication (and identity) information. This
+		enables processing of the request at a later point in time.
+		A similar situation may occur through network segmentation, which is
+		utilized in industrial systems to separate domains with different
+		security needs. Here, a similar requirement arises if the communication
+		channel carrying the requester authentication is terminated before
+		the RA/CA authorization handling of the certification request. If a
+		second communication channel is opened to forward the certification
+		request to the issuing RA/ CA, the requester authentication information
+		needs to be retained and ideally bound to the certification request.
+		This uses case is independent from timely limitations of the first use
+		case. For both cases, it is assumed that the requester authentication
+		information is utilized in the process of authorization of a
 		certification request.
-				
-		There are different options to perform store and forward of 
-		certification requests including the requester authentication 
+
+		There are different options to perform store and forward of
+		certification requests including the requester authentication
 		information:
-		
+
 		 <list style="symbols">
-            <t> Providing a trusted component (e.g., an LRA) in the target 
-   		        domain, which stores the certification request combined with 
-				the requester authentication information (based on the IDevID) 
-				and potentially the information about a successful proof of 
-				possession (of the corresponding private key) in a way 
-				prohibiting changes to the combined information. 
-				Note that the assumption is that the information elements may 
+            <t> Providing a trusted component (e.g., an LRA) in the target
+   		        domain, which stores the certification request combined with
+				the requester authentication information (based on the IDevID)
+				and potentially the information about a successful proof of
+				possession (of the corresponding private key) in a way
+				prohibiting changes to the combined information.
+				Note that the assumption is that the information elements may
 				not be cryptographically bound together.
-				Once connectivity to the backend is available, the trusted 
-				component forwards the certification request together with 
-				the requester information (authentication and proof of 
-				possession) to the off-site PKI for further processing. 
-				It is assumed that the off-site PKI in this case relies on the 
-				local pledge authentication result and thus performs the 
-				authorization and issues the requested certificate. 
-				In BRSKI the trusted component may be the EST server residing 
+				Once connectivity to the backend is available, the trusted
+				component forwards the certification request together with
+				the requester information (authentication and proof of
+				possession) to the off-site PKI for further processing.
+				It is assumed that the off-site PKI in this case relies on the
+				local pledge authentication result and thus performs the
+				authorization and issues the requested certificate.
+				In BRSKI the trusted component may be the EST server residing
 				co-located with the registrar in the target domain. </t>
 
-            <t> Utilization of authenticated self-contained objects for the 
-			    enrollment, binding the certification request and the 
-				requester authentication in a cryptographic way. This approach 
-				reduces the necessary trust in a domain component to storage 
-				and delivery. Unauthorized modifications of the requester 
-				information (request and authentication) can be detected during 
+            <t> Utilization of authenticated self-contained objects for the
+			    enrollment, binding the certification request and the
+				requester authentication in a cryptographic way. This approach
+				reduces the necessary trust in a domain component to storage
+				and delivery. Unauthorized modifications of the requester
+				information (request and authentication) can be detected during
 				the verification of the authenticated self-contained object. </t>
 		</list>
       </t>
 
-      <t>                   
-		Focus of this document the support of handling authenticated 
-		self-contained objects for bootstrapping. As it is intended to enhance 
-		BRSKI it is named BRSKI-AE, where AE stands for asynchronous enrollment. 
-		As BRSKI, BRSKI-AE results in the pledge storing an X.509 domain 
-		certificate and sufficient information for verifying the domain 
-		registrar / proxy identity (LDevID CA Certificate) as well as  
+      <t>
+		Focus of this document the support of handling authenticated
+		self-contained objects for bootstrapping. As it is intended to enhance
+		BRSKI it is named BRSKI-AE, where AE stands for asynchronous enrollment.
+		As BRSKI, BRSKI-AE results in the pledge storing an X.509 domain
+		certificate and sufficient information for verifying the domain
+		registrar / proxy identity (LDevID CA Certificate) as well as
 		domain specific X.509 device certificates (LDevID EE certificate). </t>
 
-      <t>                   
-		Based on the proposed approach, a second set of scenarios can be 
-		addressed, in which the pledge has either no direct communication path 
-		to the domain registrar, e.g., due to missing network connectivity or a 
-		different technology stack. In such scenarios the pledge is expected to 
-		act as a server rather than a client. The pledge will be triggered to 
-		generate request objects to be onboarded in the registrar's domain. 
-		For this, an additional component is introduced acting as an agent for 
-		the domain registrar (registrar-agent) towards the pledge. This could 
-		be a functionality of a commissioning tool or it may be even co-located 
-		with the registrar. 
-		In contrast to BRSKI the registrar-agent performs the object exchange 
-		with the pledge and provides/retrieves data objects to/from the domain 
-		registrar. For the interaction with the domain registrar the registrar 
+      <t>
+		Based on the proposed approach, a second set of scenarios can be
+		addressed, in which the pledge has either no direct communication path
+		to the domain registrar, e.g., due to missing network connectivity or a
+		different technology stack. In such scenarios the pledge is expected to
+		act as a server rather than a client. The pledge will be triggered to
+		generate request objects to be onboarded in the registrar's domain.
+		For this, an additional component is introduced acting as an agent for
+		the domain registrar (registrar-agent) towards the pledge. This could
+		be a functionality of a commissioning tool or it may be even co-located
+		with the registrar.
+		In contrast to BRSKI the registrar-agent performs the object exchange
+		with the pledge and provides/retrieves data objects to/from the domain
+		registrar. For the interaction with the domain registrar the registrar
 		agent will use existing BRSKI endpoints. </t>
 
-      <t>		
-		The goal is to enhance BRSKI to be applicable to the additional use 
+      <t>
+		The goal is to enhance BRSKI to be applicable to the additional use
 		cases. This is addressed by
 		<list style="symbols">
-		    <t> enhancing the well-known URI approach with an additional path 
+		    <t> enhancing the well-known URI approach with an additional path
 			    for the utilized enrollment protocol.</t>
-			<t> defining a certificate waiting indication and handling, if the 
+			<t> defining a certificate waiting indication and handling, if the
 			    certifying component is (temporarily) not available.</t>
-			<t> allowing to utilize credentials different from the pledge's 
-			    IDevID to establish a TLS connection to the domain registrar, 
-				which is necessary in case of using a registrar-agent.</t>	
-			<t> defining the interaction (dta exchange and data objects) between 
-			    a pledge acting as server an a registrar-agent and the domain 
-				registrar.</t>	
+			<t> allowing to utilize credentials different from the pledge's
+			    IDevID to establish a TLS connection to the domain registrar,
+				which is necessary in case of using a registrar-agent.</t>
+			<t> defining the interaction (dta exchange and data objects) between
+			    a pledge acting as server an a registrar-agent and the domain
+				registrar.</t>
 		  </list>
       </t>
       <t>
-	    Note that in contrast to BRSKI, BRSKI-AE assumes support of multiple 
-		enrollment protocols on the infrastructure side, allowing the pledge 
-		manufacturer to select the most appropriate. Thus, BRSKI-AE can be 
+	    Note that in contrast to BRSKI, BRSKI-AE assumes support of multiple
+		enrollment protocols on the infrastructure side, allowing the pledge
+		manufacturer to select the most appropriate. Thus, BRSKI-AE can be
 		applied for both, asynchronous and synchronous enrollment.
       </t>
 
 	</section>
-    
+
     <section title="Terminology">
-        <t> The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", 
-		    "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this 
-			document are to be interpreted as described in BCP 14 
-			<xref target="RFC2119"></xref> <xref target="RFC8174"></xref> when, 
-			and only when, they appear in all capitals, as shown here.  
-			This document relies on the terminology defined in 
-			<xref target="RFC8995" />. 
+        <t> The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+		    "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+			document are to be interpreted as described in BCP 14
+			<xref target="RFC2119"></xref> <xref target="RFC8174"></xref> when,
+			and only when, they appear in all capitals, as shown here.
+			This document relies on the terminology defined in
+			<xref target="RFC8995" />.
 			The following terms are defined additionally:</t>
 
         <t>
           <list style="hanging">
-		    <t hangText="CA:">Certification authority, issues 
+		    <t hangText="CA:">Certification authority, issues
 			   certificates. </t>
-            <t hangText="RA:">Registration authority, an optional system 
-			   component to which a CA delegates certificate management 
+            <t hangText="RA:">Registration authority, an optional system
+			   component to which a CA delegates certificate management
 			   functions such as authorization checks.</t>
-            <t hangText="LRA:">Local registration authority, an optional RA 
+            <t hangText="LRA:">Local registration authority, an optional RA
 			   system component with proximity to end entities. </t>
-            <t hangText="IED:">Intelligent Electronic Device (in essence a 
+            <t hangText="IED:">Intelligent Electronic Device (in essence a
 			   pledge). </t>
-            <t hangText="on-site:">Describes a component or service or 
+            <t hangText="on-site:">Describes a component or service or
 			   functionality available in the target deployment domain. </t>
-            <t hangText="off-site:">Describes a component or service or 
-               functionality available in an operator domain different from 
-			   the target deployment domain. This may be a central site or a 
-			   cloud service, to which only a temporary connection is available, 
+            <t hangText="off-site:">Describes a component or service or
+               functionality available in an operator domain different from
+			   the target deployment domain. This may be a central site or a
+			   cloud service, to which only a temporary connection is available,
 			   or which is in a different administrative domain. </t>
-			<t hangText="asynchronous communication:">Describes a timely 
-			   interrupted communication between an end entity and a PKI 
+			<t hangText="asynchronous communication:">Describes a timely
+			   interrupted communication between an end entity and a PKI
 			   component. </t>
-			<t hangText="synchronous communication:">Describes a timely 
-			   uninterrupted communication between an end entity and a PKI 
-			   component. </t>  			   
-			<t hangText="authenticated self-contained object:">Describes an 
-			   object, which is cryptographically bound to the EE certificate 
-			   (IDevID certificate or LDEVID certificate) of a pledge. The 
-			   binding is assumed to be provided through a digital signature 
-			   of the actual object using the corresponding private key of 
-			   the EE certificate. </t>    
+			<t hangText="synchronous communication:">Describes a timely
+			   uninterrupted communication between an end entity and a PKI
+			   component. </t>
+			<t hangText="authenticated self-contained object:">Describes an
+			   object, which is cryptographically bound to the EE certificate
+			   (IDevID certificate or LDEVID certificate) of a pledge. The
+			   binding is assumed to be provided through a digital signature
+			   of the actual object using the corresponding private key of
+			   the EE certificate. </t>
           </list>
 		</t>
     </section>
@@ -305,321 +305,321 @@
     <section title="Scope of solution">
         <section anchor="sup-env" title="Supported environment">
         <t>
-          This solution is intended to be used in domains with limited support 
+          This solution is intended to be used in domains with limited support
 		  of on-site PKI services and comprises use cases in which:
 		<list style="symbols">
-            <t> there is no registration authority available in the target 
-                domain. The connectivity to an off-site RA in an operator's 
-				network may only be available temporarily. A local store and 
-				forward device is used for the communication with the off-site 
-				services. </t>				
-            <t> authoritative actions of a LRA are limited and may not comprise 
-			    authorization of certification requests of pledges. Final 
-				authorization is done at the RA residing in the operator 
+            <t> there is no registration authority available in the target
+                domain. The connectivity to an off-site RA in an operator's
+				network may only be available temporarily. A local store and
+				forward device is used for the communication with the off-site
+				services. </t>
+            <t> authoritative actions of a LRA are limited and may not comprise
+			    authorization of certification requests of pledges. Final
+				authorization is done at the RA residing in the operator
                 domain. </t>
-            <t> the target deployment domain already has an established 
-			    certificate management approach that shall be reused to (e.g., 
+            <t> the target deployment domain already has an established
+			    certificate management approach that shall be reused to (e.g.,
 				in brownfield installations). </t>
-		</list>	 
-      
-          In addition, the solution is intended to be applicable in domains 
-		  in which pledges have no direct connection to the domain registrar, 
-		  but are expected to be managed by the registrar. This can be motivated 
-		  by pledges featuring a different technology stack or by pledges without 
-		  an existing connection to the domain registrar during bootstrapping. 
-		  These pledges are likely to act in a server role. Therefore, the 
-		  pledge has to offer endpoints on which it can be triggered for 
-		  the generation of voucher-request objects and certification 
+		</list>
+
+          In addition, the solution is intended to be applicable in domains
+		  in which pledges have no direct connection to the domain registrar,
+		  but are expected to be managed by the registrar. This can be motivated
+		  by pledges featuring a different technology stack or by pledges without
+		  an existing connection to the domain registrar during bootstrapping.
+		  These pledges are likely to act in a server role. Therefore, the
+		  pledge has to offer endpoints on which it can be triggered for
+		  the generation of voucher-request objects and certification
 		  objects as well as to provide the response objects to the pledge. </t>
         </section>
- 
+
       <section anchor="app-examples" title="Application Examples">
         <t>
-          The following examples are intended to motivate the support of 
-		  different enrollment approaches in general and asynchronous enrollment 
-		  specifically, by introducing industrial applications cases, 
-		  which could leverage BRSKI as such but also require support of 
+          The following examples are intended to motivate the support of
+		  different enrollment approaches in general and asynchronous enrollment
+		  specifically, by introducing industrial applications cases,
+		  which could leverage BRSKI as such but also require support of
 		  asynchronous operation as intended with BRSKI-AE.
 		</t>
-		
+
         <section title="Rolling stock">
 		<t>
-		  Rolling stock or railroad cars contain a variety of sensors, 
-		  actuators, and controllers, which communicate within the railroad car 
-		  but also exchange information between railroad cars building a train, 
-		  or with a backend. These devices are typically unaware of backend 
-		  connectivity. Managing certificates may be done during maintenance 
-		  cycles of the railroad car, but can already be prepared during 
-		  operation. The preparation may comprise the generation of certification 
-		  requests by the components which are collected and forwarded for 
+		  Rolling stock or railroad cars contain a variety of sensors,
+		  actuators, and controllers, which communicate within the railroad car
+		  but also exchange information between railroad cars building a train,
+		  or with a backend. These devices are typically unaware of backend
+		  connectivity. Managing certificates may be done during maintenance
+		  cycles of the railroad car, but can already be prepared during
+		  operation. The preparation may comprise the generation of certification
+		  requests by the components which are collected and forwarded for
 		  processing, once the railroad car is connected to the operator backend.
-		  The authorization of the certification request is then done based on 
-		  the operator's asset/inventory information in the backend. 
+		  The authorization of the certification request is then done based on
+		  the operator's asset/inventory information in the backend.
 		</t>
-        </section>		
-		   
+        </section>
+
         <section title="Building automation">
 		<t>
-		  In building automation, a use case can be described by a detached 
-		  building or the basement of a building equipped with sensor, 
-		  actuators, and controllers connected, but with only limited or no 
-		  connection to the centralized building management system. This 
-		  limited connectivity may be during the installation time but also 
-		  during operation time. During the installation in the basement, a 
-		  service technician collects the necessary information from the 
-		  basement network and provides them to the central building management 
-		  system, e.g., using a laptop or even a mobile phone to transport the 
-		  information. This information may comprise parameters and settings 
-		  required in the operational phase of the sensors/actuators, like a 
-		  certificate issued by the operator to authenticate against other 
+		  In building automation, a use case can be described by a detached
+		  building or the basement of a building equipped with sensor,
+		  actuators, and controllers connected, but with only limited or no
+		  connection to the centralized building management system. This
+		  limited connectivity may be during the installation time but also
+		  during operation time. During the installation in the basement, a
+		  service technician collects the necessary information from the
+		  basement network and provides them to the central building management
+		  system, e.g., using a laptop or even a mobile phone to transport the
+		  information. This information may comprise parameters and settings
+		  required in the operational phase of the sensors/actuators, like a
+		  certificate issued by the operator to authenticate against other
 		  components and services. </t>
-		
+
 		<t>
-		  The collected information may be provided by a domain registrar 
-		  already existing in the installation network. In this case 
-		  connectivity to the backend PKI may be facilitated by the service 
-		  technician's laptop.  
-		  Contrary, the information can also be collected from the 
-		  pledges directly and provided to a domain registrar deployed in a 
-		  different network. In this cases connectivity to the domain registrar 
+		  The collected information may be provided by a domain registrar
+		  already existing in the installation network. In this case
+		  connectivity to the backend PKI may be facilitated by the service
+		  technician's laptop.
+		  Contrary, the information can also be collected from the
+		  pledges directly and provided to a domain registrar deployed in a
+		  different network. In this cases connectivity to the domain registrar
 		  may be facilitated by the service technician's laptop. </t>
 
-		</section>		
-		  
+		</section>
+
 		<section title="Substation automation">
 		<t>
-		  In electrical substation automation a control center typically hosts 
-		  PKI services to issue certificates for Intelligent Electronic Devices 
-		  (IED)s operated in a substation. Communication between the substation 
-		  and control center is done through a proxy/gateway/DMZ, which 
-		  terminates protocol flows. Note that <xref target="NERC-CIP-005-5" /> 
-		  requires inspection of protocols at the boundary of a security 
+		  In electrical substation automation a control center typically hosts
+		  PKI services to issue certificates for Intelligent Electronic Devices
+		  (IED)s operated in a substation. Communication between the substation
+		  and control center is done through a proxy/gateway/DMZ, which
+		  terminates protocol flows. Note that <xref target="NERC-CIP-005-5" />
+		  requires inspection of protocols at the boundary of a security
 		  perimeter (the substation in this case).
-		  In addition, security management in substation automation assumes 
-		  central support of different enrollment protocols to facilitate the 
-		  capabilities of IEDs from different vendors. The IEC standard 
-		  IEC62351-9 <xref target="IEC-62351-9" /> specifies the mandatory 
-		  support of two enrollment protocols, SCEP <xref target="RFC8894" /> 
-		  and EST <xref target="RFC7030" /> for the infrastructure side, while 
+		  In addition, security management in substation automation assumes
+		  central support of different enrollment protocols to facilitate the
+		  capabilities of IEDs from different vendors. The IEC standard
+		  IEC62351-9 <xref target="IEC-62351-9" /> specifies the mandatory
+		  support of two enrollment protocols, SCEP <xref target="RFC8894" />
+		  and EST <xref target="RFC7030" /> for the infrastructure side, while
 		  the IED must only support one of the two. </t>
-        </section>	
- 
+        </section>
+
 		<section title="Electric vehicle charging infrastructure">
 		<t>
-		  For the electric vehicle charging infrastructure protocols have been 
-		  defined for the interaction between the electric vehicle (EV) and the 
-		  charging point (e.g., ISO 15118-2 <xref target="ISO-IEC-15118-2" />) 
-		  as well as between the charging point and the charging point operator  
-		  (e.g. OCPP <xref target="OCPP" />). Depending on the authentication 
-		  model, unilateral or mutual authentication is required. In both cases 
-		  the charging point uses an X.509 certificate to authenticate itself 
-		  in the context of a TLS connection between the EV and 
-		  the charging point. The management of this certificate depends 
-		  (beyond others) on the selected backend connectivity protocol. 
-		  Specifically, in case of OCPP it is intended as single communication 
-		  protocol between the charging point and the backend carrying all 
-		  information to control the charging operations and maintain the 
-		  charging point itself. This means that the certificate management is 
-		  intended to be handled in-band of OCPP. This requires to be able to 
-		  encapsulate the certificate management exchanges in a transport 
-		  independent way. Authenticated self-containment will ease this by 
-		  allowing the transport without a separate enrollment protocol. This 
-		  provides a binding of the exchanges to the identity of the 
+		  For the electric vehicle charging infrastructure protocols have been
+		  defined for the interaction between the electric vehicle (EV) and the
+		  charging point (e.g., ISO 15118-2 <xref target="ISO-IEC-15118-2" />)
+		  as well as between the charging point and the charging point operator
+		  (e.g. OCPP <xref target="OCPP" />). Depending on the authentication
+		  model, unilateral or mutual authentication is required. In both cases
+		  the charging point uses an X.509 certificate to authenticate itself
+		  in the context of a TLS connection between the EV and
+		  the charging point. The management of this certificate depends
+		  (beyond others) on the selected backend connectivity protocol.
+		  Specifically, in case of OCPP it is intended as single communication
+		  protocol between the charging point and the backend carrying all
+		  information to control the charging operations and maintain the
+		  charging point itself. This means that the certificate management is
+		  intended to be handled in-band of OCPP. This requires to be able to
+		  encapsulate the certificate management exchanges in a transport
+		  independent way. Authenticated self-containment will ease this by
+		  allowing the transport without a separate enrollment protocol. This
+		  provides a binding of the exchanges to the identity of the
 		  communicating endpoints.</t>
-        </section>	
+        </section>
 
 		<section title="Infrastructure isolation policy">
 		<t>
-	      This refers to any case in which network infrastructure is normally 
-		  isolated from the Internet as a matter of policy, most likely for 
-		  security reasons. In such a case, limited access to external PKI 
-		  resources will be allowed in carefully controlled short periods of 
-		  time, for example when a batch of new devices are deployed, but 
+	      This refers to any case in which network infrastructure is normally
+		  isolated from the Internet as a matter of policy, most likely for
+		  security reasons. In such a case, limited access to external PKI
+		  resources will be allowed in carefully controlled short periods of
+		  time, for example when a batch of new devices are deployed, but
 		  impossible at other times. </t>
-        </section>	
-		
+        </section>
+
 		<section title="Less operational security in the target domain">
 		<t>
-	      The registration point performing the authorization of a certificate 
-		  request is a critical PKI component and therefore implicates higher 
-		  operational security than other components utilizing the issued 
-		  certificates for their security features. CAs may also demand higher 
-		  security in the registration procedures. Especially the CA/Browser 
-		  forum currently increases the security requirements in the certificate 
-		  issuance procedures for publicly trusted certificates. 
-		  There may be the situation that the target domain does not offer 
-		  enough security to operate a registration point and therefore wants 
-		  to transfer this service to a backend that offers a higher level of 
+	      The registration point performing the authorization of a certificate
+		  request is a critical PKI component and therefore implicates higher
+		  operational security than other components utilizing the issued
+		  certificates for their security features. CAs may also demand higher
+		  security in the registration procedures. Especially the CA/Browser
+		  forum currently increases the security requirements in the certificate
+		  issuance procedures for publicly trusted certificates.
+		  There may be the situation that the target domain does not offer
+		  enough security to operate a registration point and therefore wants
+		  to transfer this service to a backend that offers a higher level of
 		  operational security. </t>
         </section>
        </section>
       </section>
-	
+
       <section anchor="req-sol" title="Requirement discussion and mapping to solution elements">
-	    <t> For the requirements discussion it is assumed that the domain 
-		    registrar receiving a certification request as authenticated 
-			self-contained object is not the authorization point for this 
-			certification request. If the domain registrar is the authorization 
-			point and the pledge has a direct connection to the registrar, 
-			BRSKI can be used directly. Note that BRSKI-AE could also be used 
+	    <t> For the requirements discussion it is assumed that the domain
+		    registrar receiving a certification request as authenticated
+			self-contained object is not the authorization point for this
+			certification request. If the domain registrar is the authorization
+			point and the pledge has a direct connection to the registrar,
+			BRSKI can be used directly. Note that BRSKI-AE could also be used
 			in this case. </t>
-			
-		<t> Based on the intended target environment described in 
-		    <xref target="sup-env" /> and the motivated application examples 
-		    described in <xref target="app-examples" /> the following 
-		    base requirements are derived to support authenticated self-contained 
-		    objects as container carrying the certification request and further 
+
+		<t> Based on the intended target environment described in
+		    <xref target="sup-env" /> and the motivated application examples
+		    described in <xref target="app-examples" /> the following
+		    base requirements are derived to support authenticated self-contained
+		    objects as container carrying the certification request and further
 		    information to support asynchronous operation. </t>
    	    <t> At least the following properties are required:
 			<list style="symbols">
-			  <t> Proof of Possession: proves to possess and control the private 
-			      key corresponding to the public key contained in the 
-				  certification request, typically by adding a signature using 
-				  the private key. </t> 
-			  <t> Proof of Identity: provides data-origin authentication of a 
-			      data object, e.g., a certificate request, utilizing an existing 
-				  IDevID. Certificate updates may utilize the certificate that 
-				  is to be updated.</t> 
+			  <t> Proof of Possession: proves to possess and control the private
+			      key corresponding to the public key contained in the
+				  certification request, typically by adding a signature using
+				  the private key. </t>
+			  <t> Proof of Identity: provides data-origin authentication of a
+			      data object, e.g., a certificate request, utilizing an existing
+				  IDevID. Certificate updates may utilize the certificate that
+				  is to be updated.</t>
 		    </list>
-	
-			Solution examples (not complete) based on existing technology are 
+
+			Solution examples (not complete) based on existing technology are
 		    provided with the focus on existing IETF documents:
 		   <list style="symbols">
-        <t> Certification request objects: Certification requests are 
-			structures protecting only the integrity of the contained data 
-			providing a proof-of-private-key-possession for locally 
+        <t> Certification request objects: Certification requests are
+			structures protecting only the integrity of the contained data
+			providing a proof-of-private-key-possession for locally
 			generated key pairs. Examples for certification requests are:
       		<list style="symbols">
-			  <t> PKCS#10 <xref target="RFC2986" />: Defines a structure 
-			      for a certification request. The structure is signed to 
-				  ensure integrity protection and proof of possession of 
-				  the private key of the requester that corresponds to the 
-				  contained public key.</t> 
-			  <t> CRMF <xref target="RFC4211" />: Defines a structure for 
-			      the certification request message. The structure supports 
-				  integrity protection and proof of possession, through a 
-				  signature generated over parts of the structure by using 
-				  the private key corresponding to the contained public 
-				  key. CRMF also supports further proof-of-possession methods 
-				  for key pairs not capable to be used for signing. </t> 
+			  <t> PKCS#10 <xref target="RFC2986" />: Defines a structure
+			      for a certification request. The structure is signed to
+				  ensure integrity protection and proof of possession of
+				  the private key of the requester that corresponds to the
+				  contained public key.</t>
+			  <t> CRMF <xref target="RFC4211" />: Defines a structure for
+			      the certification request message. The structure supports
+				  integrity protection and proof of possession, through a
+				  signature generated over parts of the structure by using
+				  the private key corresponding to the contained public
+				  key. CRMF also supports further proof-of-possession methods
+				  for key pairs not capable to be used for signing. </t>
 			</list>
-			
-			Note that the integrity of the certification request is bound to 
-			the public key contained in the certification request by 
-			performing the signature operation with the corresponding 
-			private key. In the considered application examples, this is 
-			not sufficient to provide data origin authentication and needs to 
-			be bound to the existing credential of the pledge (IDevID) 
-			additionally. This binding supports the 
-			authorization decision for the certification request through 
-			the provisioning of a proof of identity. The binding of data 
-			origin authentication to the certification request may be 
+
+			Note that the integrity of the certification request is bound to
+			the public key contained in the certification request by
+			performing the signature operation with the corresponding
+			private key. In the considered application examples, this is
+			not sufficient to provide data origin authentication and needs to
+			be bound to the existing credential of the pledge (IDevID)
+			additionally. This binding supports the
+			authorization decision for the certification request through
+			the provisioning of a proof of identity. The binding of data
+			origin authentication to the certification request may be
 			delegated to the protocol used for certificate management.</t>
-		
-        <t> Proof of Identity options: The certification request should be 
-		    bound to an existing credential (here IDevID) to enable a proof 
-			of identity and based on it an authorization of the certification 
-			request. 
-			The binding may be realized through security options in an 
-			underlying transport protocol if the authorization of the  
+
+        <t> Proof of Identity options: The certification request should be
+		    bound to an existing credential (here IDevID) to enable a proof
+			of identity and based on it an authorization of the certification
+			request.
+			The binding may be realized through security options in an
+			underlying transport protocol if the authorization of the
 			certification request is done at the next communication hop.
-			Alternatively, this binding can be done by a wrapping signature 
-			employing an existing credential (initial: IDevID, 
-			renewal: LDevID). 
-			This requirement is addressed by existing enrollment protocols 
+			Alternatively, this binding can be done by a wrapping signature
+			employing an existing credential (initial: IDevID,
+			renewal: LDevID).
+			This requirement is addressed by existing enrollment protocols
 			in different ways, for instance:
 			<list style="symbols">
-			  <t> EST <xref target="RFC7030" />: Utilizes PKCS#10 to 
-			      encode the certification request. The Certificate Signing 
-				  Request (CSR) may contain a binding to the underlying TLS 
-				  by including the tls-unique value in the self-signed CSR 
-				  structure. The tls-unique value is one result of the 
-				  TLS handshake. As the TLS handshake is performed mutually 
-				  authenticated and the pledge utilized its IDevID for it, 
-				  the proof of identity can be provided by the binding to 
+			  <t> EST <xref target="RFC7030" />: Utilizes PKCS#10 to
+			      encode the certification request. The Certificate Signing
+				  Request (CSR) may contain a binding to the underlying TLS
+				  by including the tls-unique value in the self-signed CSR
+				  structure. The tls-unique value is one result of the
+				  TLS handshake. As the TLS handshake is performed mutually
+				  authenticated and the pledge utilized its IDevID for it,
+				  the proof of identity can be provided by the binding to
 				  the TLS session. This is supported in EST using the
-				  simpleenroll endpoint. To avoid the binding to the underlying 
-				  authentication in the transport layer, EST offers the 
-				  support of a wrapping the CSR with an existing certificate 
-				  by using Full PKI Request messages.</t> 
-			  <t> SCEP <xref target="RFC8894" />: Provides the 
-			      option to utilize either an existing secret (password) or 
-				  an existing certificate to protect the CSR based on 
+				  simpleenroll endpoint. To avoid the binding to the underlying
+				  authentication in the transport layer, EST offers the
+				  support of a wrapping the CSR with an existing certificate
+				  by using Full PKI Request messages.</t>
+			  <t> SCEP <xref target="RFC8894" />: Provides the
+			      option to utilize either an existing secret (password) or
+				  an existing certificate to protect the CSR based on
 				  SCEP Secure Message Objects using CMS wrapping
-				  (<xref target="RFC5652" />). Note that the wrapping using 
-				  an existing IDevID credential in SCEP is referred to as 
-				  renewal. SCEP therefore does not rely on the security of 
-				  an underlying transport. </t> 
-			  <t> CMP <xref target="RFC4210" /> Provides the option to 
-				  utilize either an existing secret (password) or an 
-				  existing certificate to protect the PKIMessage containing 
-				  the certification request. The certification request is 
+				  (<xref target="RFC5652" />). Note that the wrapping using
+				  an existing IDevID credential in SCEP is referred to as
+				  renewal. SCEP therefore does not rely on the security of
+				  an underlying transport. </t>
+			  <t> CMP <xref target="RFC4210" /> Provides the option to
+				  utilize either an existing secret (password) or an
+				  existing certificate to protect the PKIMessage containing
+				  the certification request. The certification request is
 				  encoded utilizing CRMF. PKCS#10 is optionally supported.
-				  The proof of identity of the PKIMessage containing the 
-				  certification request can be achieved by using IDevID 
-				  credentials to a PKIProtection carrying the actual signature 
-				  value. CMP therefore does not rely on the security of an 
-				  underlying transport protocol.</t> 
-			  <t> CMC <xref target="RFC5272" /> Provides the option to 
-			      utilize either an existing secret (password) or an 
-				  existing certificate to protect the certification request 
-				  (either in CRMF or PKCS#10) based on CMS 
-			 	  <xref target="RFC5652" />). Here a FullCMCRequest can 
-				  be used, which allows signing with an existing IDevID 
-				  credential to provide a proof of identity. CMC therefore 
-				  does not rely on the security of an underlying transport.</t> 
+				  The proof of identity of the PKIMessage containing the
+				  certification request can be achieved by using IDevID
+				  credentials to a PKIProtection carrying the actual signature
+				  value. CMP therefore does not rely on the security of an
+				  underlying transport protocol.</t>
+			  <t> CMC <xref target="RFC5272" /> Provides the option to
+			      utilize either an existing secret (password) or an
+				  existing certificate to protect the certification request
+				  (either in CRMF or PKCS#10) based on CMS
+			 	  <xref target="RFC5652" />). Here a FullCMCRequest can
+				  be used, which allows signing with an existing IDevID
+				  credential to provide a proof of identity. CMC therefore
+				  does not rely on the security of an underlying transport.</t>
 			</list>
-        </t>	
+        </t>
 	  </list>
-		         
+
       Note that besides the already existing enrollment protocols there is
-      ongoing work in the ACE WG to define an encapsulation of EST messages in 
-      OSCORE to result in a TLS independent way of protecting EST. This 
-      approach <xref target="I-D.selander-ace-coap-est-oscore" /> may be  
+      ongoing work in the ACE WG to define an encapsulation of EST messages in
+      OSCORE to result in a TLS independent way of protecting EST. This
+      approach <xref target="I-D.selander-ace-coap-est-oscore" /> may be
 	  considered as further variant. </t>
     </section>
 
 
     <section anchor="architecture" title="Architectural Overview and Communication Exchanges">
-      <t> To support asynchronous enrollment, the base system architecture 
-	      defined in BRSKI <xref target="RFC8995" /> 
-		  is enhanced to facilitate the two target use cases.  
+      <t> To support asynchronous enrollment, the base system architecture
+	      defined in BRSKI <xref target="RFC8995" />
+		  is enhanced to facilitate the two target use cases.
 		  <list style="symbols">
-				  <t> Use case 1 (Pledge-initiator-mode): the pledge requests 
-				      certificates from a PKI operated off-site via the domain 
-					  registrar. 
-					  The communication model follows the BRSKI model in which 
+				  <t> Use case 1 (Pledge-initiator-mode): the pledge requests
+				      certificates from a PKI operated off-site via the domain
+					  registrar.
+					  The communication model follows the BRSKI model in which
 					  the pledge initiates the communication.</t>
-				  <t> Use case 2 (Pledge-responder-mode): allows delegated 
-				      bootstrapping using a registrar-agent instead a direct 
-					  connection from the pledge to the domain registrar. 
-					  The communication model between registrar-agent and 
-					  pledge assumes that the pledge is acting as server and 
-					  responds to requests. </t>  
+				  <t> Use case 2 (Pledge-responder-mode): allows delegated
+				      bootstrapping using a registrar-agent instead a direct
+					  connection from the pledge to the domain registrar.
+					  The communication model between registrar-agent and
+					  pledge assumes that the pledge is acting as server and
+					  responds to requests. </t>
 		  </list>
-		  Both use cases are described in the next subsections. They utilize 
-		  the existing BRSKI architecture elements as much as possible. 
-		  Necessary enhancements to support authenticated self-contained objects 
-		  for certificate enrollment are kept on a minimum to ensure reuse of 
+		  Both use cases are described in the next subsections. They utilize
+		  the existing BRSKI architecture elements as much as possible.
+		  Necessary enhancements to support authenticated self-contained objects
+		  for certificate enrollment are kept on a minimum to ensure reuse of
 		  already defined architecture elements and interactions. </t>
-      
-	  <t> For the authenticated self-contained objects used for the certification 
-	      request, BRSKI-AE relies on the defined message wrapping mechanisms 
-		  of the enrollment protocols stated in <xref target="req-sol" /> 
-		  above. </t>		  
-	  
+
+	  <t> For the authenticated self-contained objects used for the certification
+	      request, BRSKI-AE relies on the defined message wrapping mechanisms
+		  of the enrollment protocols stated in <xref target="req-sol" />
+		  above. </t>
+
       <section anchor="uc1" title="Use Case 1 (pledge-initiator-mode): Support of off-site PKI service">
-        <t> One assumption of BRSKI-AE is that the authorization of a 
-		    certification request is performed based on an authenticated 
-		    self-contained object, binding the certification request to the 
-		    authentication using the IDevID. This supports interaction with 
-		    off-site or off-line PKI (RA/CA) components. 
-		    In addition, the authorization of the certification request may not 
-		    be done by the domain registrar but by a PKI residing in the backend 
-		    of the domain operator (off-site) as described in 
-		    <xref target="sup-env" />. Also, the certification request may be 
-			piggybacked by another protocol. This leads to changes in the 
-			placement or enhancements of the logical elements as shown in 
+        <t> One assumption of BRSKI-AE is that the authorization of a
+		    certification request is performed based on an authenticated
+		    self-contained object, binding the certification request to the
+		    authentication using the IDevID. This supports interaction with
+		    off-site or off-line PKI (RA/CA) components.
+		    In addition, the authorization of the certification request may not
+		    be done by the domain registrar but by a PKI residing in the backend
+		    of the domain operator (off-site) as described in
+		    <xref target="sup-env" />. Also, the certification request may be
+			piggybacked by another protocol. This leads to changes in the
+			placement or enhancements of the logical elements as shown in
 		    <xref target="uc1figure" />. </t>
 
 <figure anchor="uc1figure" title="Architecture overview using off-site PKI components">
@@ -632,164 +632,164 @@
    |                                       | S igning     |Tracker  |
    |                                       | A uthority   |         |
    |                                       +--------------+---------+
-   |                                                      ^          
-   |                                                      |    
-   V                                                      |      
-+--------+     .........................................  |         
-|        |     .                                       .  | BRSKI-        
-|        |     .  +------------+       +------------+  .  | MASA               
-| Pledge |     .  |   Join     |       | Domain     <-----+   
-|        |     .  |   Proxy    |       | Registrar/ |  .    
-|        <-------->............<-------> Enrollment |  .    
-|        |     .  |        BRSKI-AE    | Proxy      |  .   
-| IDevID |     .  |            |       +------^-----+  .    
-|        |     .  +------------+              |        .   
-|        |     .                              |        .   
-+--------+     ...............................|.........   
-                "on-site domain" components   |            
-                                              |e.g., RFC 7030,                 
-                                              |      RFC 4210, ...                    
- .............................................|.....................   
- . +---------------------------+     +--------v------------------+ .   
+   |                                                      ^
+   |                                                      |
+   V                                                      |
++--------+     .........................................  |
+|        |     .                                       .  | BRSKI-
+|        |     .  +------------+       +------------+  .  | MASA
+| Pledge |     .  |   Join     |       | Domain     <-----+
+|        |     .  |   Proxy    |       | Registrar/ |  .
+|        <-------->............<-------> Enrollment |  .
+|        |     .  |        BRSKI-AE    | Proxy      |  .
+| IDevID |     .  |            |       +------^-----+  .
+|        |     .  +------------+              |        .
+|        |     .                              |        .
++--------+     ...............................|.........
+                "on-site domain" components   |
+                                              |e.g., RFC 7030,
+                                              |      RFC 4210, ...
+ .............................................|.....................
+ . +---------------------------+     +--------v------------------+ .
  . | Public Key Infrastructure |<----+ PKI RA                    | .
- . | PKI CA                    |---->+                           | .   
+ . | PKI CA                    |---->+                           | .
  . +---------------------------+     +---------------------------+ .
  ...................................................................
          "off-site domain" components
 ]]></artwork>
 </figure>
 
-      <t> The architecture overview in <xref target="uc1figure" /> utilizes 
-	      the same logical elements as BRSKI but with a different placement in 
-		  the deployment architecture for some of the elements. 
-		  The main difference is the placement of the PKI RA/CA component, which 
-		  is performing the authorization decision for the certification request 
-		  message. It is placed in the off-site domain of the operator (not 
-		  the deployment site directly), which may have no or only temporary 
-		  connectivity to the deployment or on-site domain of the pledge. 
-		  This is to underline the authorization decision for the certification 
+      <t> The architecture overview in <xref target="uc1figure" /> utilizes
+	      the same logical elements as BRSKI but with a different placement in
+		  the deployment architecture for some of the elements.
+		  The main difference is the placement of the PKI RA/CA component, which
+		  is performing the authorization decision for the certification request
+		  message. It is placed in the off-site domain of the operator (not
+		  the deployment site directly), which may have no or only temporary
+		  connectivity to the deployment or on-site domain of the pledge.
+		  This is to underline the authorization decision for the certification
 		  request in the backend rather than on-site.
-		    
-		  The following list describes the components in the target domain: 
+
+		  The following list describes the components in the target domain:
 		  <list style="symbols">
             <t> Join Proxy: same functionality as described in BRSKI. </t>
 
-            <t> Domain Registrar / Enrollment Proxy: In general the domain 
-			    registrar proxy has a similar functionality regarding the 
-				imprinting of the pledge in the deployment domain to facilitate 
-				the communication of the pledge with the MASA and the PKI. 
-				Different is the authorization of the certification 
-				request. BRSKI-AE allows to perform this in the operator's 
-				backend (off-site), and not directly at the domain registrar. 
+            <t> Domain Registrar / Enrollment Proxy: In general the domain
+			    registrar proxy has a similar functionality regarding the
+				imprinting of the pledge in the deployment domain to facilitate
+				the communication of the pledge with the MASA and the PKI.
+				Different is the authorization of the certification
+				request. BRSKI-AE allows to perform this in the operator's
+				backend (off-site), and not directly at the domain registrar.
 				<list style="symbols">
-				<t> Voucher exchange: The voucher exchange with the MASA  via 
-				    the domain registrar is performed as described in BRSKI 
+				<t> Voucher exchange: The voucher exchange with the MASA  via
+				    the domain registrar is performed as described in BRSKI
 					<xref target="RFC8995" /> .</t>
-                <t> Certificate enrollment: For the pledge enrollment the 
+                <t> Certificate enrollment: For the pledge enrollment the
 				    domain registrar in the deployment domain supports the
-					adoption of the pledge in the domain based on the voucher 
-					request. Nevertheless, it may not have sufficient 
-					information for authorizing the certification request. 
-					If the authorization of the certification request is done 
-					in the off-site domain, the domain registrar forwards the 
-					certification request to the RA to perform the authorization. 
-					Note that this requires, that the certification request object 
-					is enhanced with a proof-of-identity to allow the authorization 
-					based on the bound identity information of the pledge. As 
-					stated above, this can be done by an additional signature 
-					using the IDevID. 
-					The domain registrar here acts as an enrollment proxy or 
-					local registration authority. It is also able to handle the 
-					case having no connection temporarily to an off-site PKI, 
-					by storing the authenticated certification request and 
-					forwarding it to the RA upon reestablished connectivity. 
-					As authenticated self-contained objects are used, it 
-					requires an enhancement of the domain registrar. This is 
-					done by supporting alternative enrollment approaches 
-					(protocol options, protocols, encoding) by enhancing the 
+					adoption of the pledge in the domain based on the voucher
+					request. Nevertheless, it may not have sufficient
+					information for authorizing the certification request.
+					If the authorization of the certification request is done
+					in the off-site domain, the domain registrar forwards the
+					certification request to the RA to perform the authorization.
+					Note that this requires, that the certification request object
+					is enhanced with a proof-of-identity to allow the authorization
+					based on the bound identity information of the pledge. As
+					stated above, this can be done by an additional signature
+					using the IDevID.
+					The domain registrar here acts as an enrollment proxy or
+					local registration authority. It is also able to handle the
+					case having no connection temporarily to an off-site PKI,
+					by storing the authenticated certification request and
+					forwarding it to the RA upon reestablished connectivity.
+					As authenticated self-contained objects are used, it
+					requires an enhancement of the domain registrar. This is
+					done by supporting alternative enrollment approaches
+					(protocol options, protocols, encoding) by enhancing the
 					addressing scheme to communicate with the domain registrar
 					(see <xref target="addressing" />).</t>
 				</list>
 			</t>
-		  </list>	 
- 		  
-		  The following list describes the vendor related components/service 
-		  outside the deployment domain: 
+		  </list>
+
+		  The following list describes the vendor related components/service
+		  outside the deployment domain:
 		  <list style="symbols">
-            <t> MASA: general functionality as described in 
-			    <xref target="RFC8995" />. 
-				Assumption is that the interaction with the MASA may be 
-				synchronous (voucher request with nonce) or asynchronous 
+            <t> MASA: general functionality as described in
+			    <xref target="RFC8995" />.
+				Assumption is that the interaction with the MASA may be
+				synchronous (voucher request with nonce) or asynchronous
 				(voucher request without nonce).  </t>
-				
-			<t> Ownership tracker: as defined in 
+
+			<t> Ownership tracker: as defined in
 			    <xref target="RFC8995" />. </t>
 		  </list>
-		  
-		  The following list describes the operator related components/service 
-		  operated in the backend: 
+
+		  The following list describes the operator related components/service
+		  operated in the backend:
 		  <list style="symbols">
-            <t> PKI RA: Performs certificate management functions (validation 
-			    of certification requests, interaction with inventory/asset 
-				management for authorization of certification requests, etc.) 
-				for issuing, updating, and revoking certificates for a domain 
-				as a centralized infrastructure for the domain operator. 
-				The inventory (asset) management may be a separate component 
+            <t> PKI RA: Performs certificate management functions (validation
+			    of certification requests, interaction with inventory/asset
+				management for authorization of certification requests, etc.)
+				for issuing, updating, and revoking certificates for a domain
+				as a centralized infrastructure for the domain operator.
+				The inventory (asset) management may be a separate component
 				or integrated into the RA directly. </t>
-				
-            <t> PKI CA: Performs certificate generation by signing the 
-			    certificate structure provided in the certification request. </t>		  
-		  </list>	
+
+            <t> PKI CA: Performs certificate generation by signing the
+			    certificate structure provided in the certification request. </t>
+		  </list>
 	    </t>
-		
-        <t> Based on BRSKI and the architectural changes the original protocol 
-		    flow is divided into three phases showing commonalities and 
-			differences to the original approach as depicted in the following.	
+
+        <t> Based on BRSKI and the architectural changes the original protocol
+		    flow is divided into three phases showing commonalities and
+			differences to the original approach as depicted in the following.
 		</t>
 		<t>
 		  <list style="symbols">
             <t> Discovery phase (same as BRSKI) </t>
-            <t> Voucher exchange with deployment domain registrar 
+            <t> Voucher exchange with deployment domain registrar
 			   (same as BRSKI). </t>
-            <t> Enrollment phase (changed to support the application of 
+            <t> Enrollment phase (changed to support the application of
 			    authenticated self-contained objects). </t>
 		  </list>
         </t>
         <section title="Behavior of a pledge">
-        <t> The behavior of a pledge as described in <xref target="RFC8995" /> 
-		    is kept with one exception. After finishing the imprinting phase (4) 
-			the enrollment phase (5) is performed with a method supporting 
-			authenticated self-contained objects. Using EST with simple-enroll 
-			cannot be applied here, as it binds the pledge authentication with 
-			the existing IDevID to the transport channel (TLS) rather than to 
-			the certification request object directly. This authentication in 
-			the transport layer is not visible / verifiable at the authorization 
-			point in the off-site domain. <xref target="exist_prot" /> discusses  
-			potential enrollment protocols and options applicable. 
+        <t> The behavior of a pledge as described in <xref target="RFC8995" />
+		    is kept with one exception. After finishing the imprinting phase (4)
+			the enrollment phase (5) is performed with a method supporting
+			authenticated self-contained objects. Using EST with simple-enroll
+			cannot be applied here, as it binds the pledge authentication with
+			the existing IDevID to the transport channel (TLS) rather than to
+			the certification request object directly. This authentication in
+			the transport layer is not visible / verifiable at the authorization
+			point in the off-site domain. <xref target="exist_prot" /> discusses
+			potential enrollment protocols and options applicable.
 			</t>
        </section>
-		
-		
-	    <section anchor="discovery" 
+
+
+	    <section anchor="discovery"
 	           title="Pledge - Registrar discovery and voucher exchange">
-	    <t> The discovery phase is applied as specified in 
+	    <t> The discovery phase is applied as specified in
 		    <xref target="RFC8995" />. </t>
 	    </section>
 
-	    <section anchor="vexchange" 
+	    <section anchor="vexchange"
 		       title="Registrar - MASA voucher exchange">
-	    <t> The voucher exchange is performed as specified in 
+	    <t> The voucher exchange is performed as specified in
 			<xref target="RFC8995" />. </t>
  	    </section>
 
-	    <section anchor="enroll" 
+	    <section anchor="enroll"
 			   title="Pledge - Registrar - RA/CA certificate enrollment">
-	    <t> As stated in <xref target="req-sol" /> the enrollment shall be 
+	    <t> As stated in <xref target="req-sol" /> the enrollment shall be
 		    performed using an authenticated self-contained object providing
 			proof of possession and proof of identity. </t>
- 
+
 <figure anchor="enrollfigure" title="Certificate enrollment">
-<artwork name="" type="" align="left" alt=""><![CDATA[  
+<artwork name="" type="" align="left" alt=""><![CDATA[
 +--------+         +---------+    +------------+     +------------+
 | Pledge |         | Circuit |    | Domain     |     | Operator   |
 |        |         | Join    |    | Registrar  |     | RA/CA      |
@@ -831,119 +831,119 @@
   |                                         |[optional]          |
   |                                         |--- Cert Confirm -->|
   |                                         |<-- PKI Confirm ----|
-  |<------------- PKI/Registrar Confirm ----|                    | 
+  |<------------- PKI/Registrar Confirm ----|                    |
 ]]></artwork>
 </figure>
-		
-		<t> The following list provides an abstract description of the flow 
+
+		<t> The following list provides an abstract description of the flow
 		    depicted in <xref target="enrollfigure" />.
 		<list style="symbols">
-            <t> CA Cert Request: The pledge SHOULD request the full distribution 
-			    of CA Certificates. This ensures that the pledge has the 
-				complete set of current CA certificates beyond the 
-				pinned-domain-cert (which may be the domain registrar certificate 
+            <t> CA Cert Request: The pledge SHOULD request the full distribution
+			    of CA Certificates. This ensures that the pledge has the
+				complete set of current CA certificates beyond the
+				pinned-domain-cert (which may be the domain registrar certificate
 				contained in the voucher). </t>
-            <t> CA Cert Response: Contains at least one CA certificate of 
+            <t> CA Cert Response: Contains at least one CA certificate of
 			    the issuing CA. </t>
-            <t> Attribute Request: Typically, the automated bootstrapping occurs 
-			    without local administrative configuration of the pledge.  
-				Nevertheless, there are cases, in which the pledge may also 
-				include additional attributes specific to the deployment domain 
-				into the certification request. To get these attributes in 
+            <t> Attribute Request: Typically, the automated bootstrapping occurs
+			    without local administrative configuration of the pledge.
+				Nevertheless, there are cases, in which the pledge may also
+				include additional attributes specific to the deployment domain
+				into the certification request. To get these attributes in
 				advance, the attribute request SHOULD be used. </t>
-            <t> Attribute Response: Contains the attributes to be included 
+            <t> Attribute Response: Contains the attributes to be included
 			    in the certification request message. </t>
-            <t> Cert Request: Depending on the utilized enrollment protocol, 
-			    this certification request contains the authenticated 
-				self-contained object ensuring both, proof-of-possession of the 
-				corresponding private key and proof-of-identity of the 
+            <t> Cert Request: Depending on the utilized enrollment protocol,
+			    this certification request contains the authenticated
+				self-contained object ensuring both, proof-of-possession of the
+				corresponding private key and proof-of-identity of the
 				requester. </t>
-            <t> Cert Response: certification response message containing the 
-			    requested certificate and potentially further information like 
+            <t> Cert Response: certification response message containing the
+			    requested certificate and potentially further information like
 				certificates of intermediary CAs on the certification path. </t>
-            <t> Cert Waiting: waiting indication for the pledge to retry 
-			    after a given time. For this a request identifier is necessary. 
-				This request identifier may be either part of the enrollment 
+            <t> Cert Waiting: waiting indication for the pledge to retry
+			    after a given time. For this a request identifier is necessary.
+				This request identifier may be either part of the enrollment
 				protocol or build based on the certification request.</t>
-			<t> Cert Polling: querying the registrar, if the certificate request 
-			    was already processed; can be answered either with another 
+			<t> Cert Polling: querying the registrar, if the certificate request
+			    was already processed; can be answered either with another
 				Cert Waiting, or a Cert Response. </t>
-            <t> Cert Confirm: confirmation message from pledge after receiving 
+            <t> Cert Confirm: confirmation message from pledge after receiving
 				and verifying the certificate. </t>
             <t> PKI/Registrar Confirm: confirmation message from PKI/registrar
 			    about reception of the pledge's certificate confirmation. </t>
 		</list>
-		   The generic messages described above can implemented using various 
-		   protocols implementing authenticated self-contained objects, 
-		   as described in <xref target="req-sol" />. Examples are available 
-		   in <xref target="exist_prot" />. 
-	    </t>		
-       </section> 
-	   
+		   The generic messages described above can implemented using various
+		   protocols implementing authenticated self-contained objects,
+		   as described in <xref target="req-sol" />. Examples are available
+		   in <xref target="exist_prot" />.
+	    </t>
+       </section>
+
         <section anchor="addressing" title="Addressing Scheme Enhancements">
-        <t> BRSKI-AE provides enhancements to the addressing scheme defined in 
-		    <xref target="RFC8995" /> to 
-			accommodate the additional handling of authenticated self-contained 
-			objects for the certification request. As this is supported by 
-			different enrollment protocols, they can be directly employed 
+        <t> BRSKI-AE provides enhancements to the addressing scheme defined in
+		    <xref target="RFC8995" /> to
+			accommodate the additional handling of authenticated self-contained
+			objects for the certification request. As this is supported by
+			different enrollment protocols, they can be directly employed
 			(see also <xref target="exist_prot" />). </t>
-			
-		<t>	The addressing scheme in BRSKI for client certificate request and 
-		    CA certificate distribution function during the enrollment uses 
-			the definition from EST <xref target="RFC7030" />, here on the 
+
+		<t>	The addressing scheme in BRSKI for client certificate request and
+		    CA certificate distribution function during the enrollment uses
+			the definition from EST <xref target="RFC7030" />, here on the
 			example on simple enroll: "/.well-known/est/simpleenroll"
-	  
+
 		    This approach is generalized to the following notation:
 		    "/.well-known/enrollment-protocol/request"
-			in which enrollment-protocol may be an already existing protocol or 
-			a newly defined approach. Note that enrollment is considered here 
-			as a sequence of at least a certification request and a certification 
-		    response. In case of existing enrollment protocols the following 
+			in which enrollment-protocol may be an already existing protocol or
+			a newly defined approach. Note that enrollment is considered here
+			as a sequence of at least a certification request and a certification
+		    response. In case of existing enrollment protocols the following
 		    notation is used proving compatibility to BRSKI:
-			
+
 		  	<list style="symbols">
-            	<t> enrollment-protocol: references either EST 
-				    <xref target="RFC7030" /> as in BRSKI or 
-					CMP, CMC, SCEP, or newly defined approaches as alternatives. 
-					Note: additional endpoints (well-known URI) at the registrar 
+            	<t> enrollment-protocol: references either EST
+				    <xref target="RFC7030" /> as in BRSKI or
+					CMP, CMC, SCEP, or newly defined approaches as alternatives.
+					Note: additional endpoints (well-known URI) at the registrar
 					may need to be defined by the utilized enrollment protocol.</t>
-            	<t> request: depending on the utilized enrollment protocol, 
-            	    the request describes the required operation at the 
-					registrar side. Enrollment protocols are expected to 
-					define the request endpoints as done by existing protocols 
+            	<t> request: depending on the utilized enrollment protocol,
+            	    the request describes the required operation at the
+					registrar side. Enrollment protocols are expected to
+					define the request endpoints as done by existing protocols
 					(see also <xref target="exist_prot" />). </t>
 		  	</list>
 		</t>
-	    </section>  	
-	  </section> 
-		
+	    </section>
+	  </section>
 
-	  
+
+
       <section anchor="uc2" title="Use Case 2 (pledge-responder-mode): Registrar-agent communication with Pledges">
-       <t> To support mutual trust establishment of pledges, not directly 
-		  connected to the domain registrar. It relies on the exchange of 
-		  authenticated self-contained objects (the voucher request/response 
-		  objects as known from BRSKI and the enrollment request/response 
-		  objects as introduced by BRSKI-AE). This approach has also been applied 
-		  also for the use case 1.  
-		  This allows independence of a potential protection provided by the 
-		  used transport protocol. </t> 
-	  <t> In contrast to BRSKI, the object exchanges performed with the help of 
-	      a registrar-agent component, supporting the interaction of 
-		  the pledge with the domain registrar. It may be an integrated 
-		  functionality of a commissioning tool. This leads to enhancements 
-		  of the logical elements in the BRSKI architecture as shown in 
-		  <xref target="uc2figure" />. 
-		  The registrar-agent interacts with the pledge to acquire and to supply 
-		  the required data objects for bootstrapping, which are also exchanged 
-		  between the registrar-agent and the domain registrar. 
-		  Moreover, the addition of the registrar-agent 
-		  also influences the sequences for the data exchange between the pledge 
-		  and the domain registrar described in 
-		  <xref target="RFC8995" />.  
-		  The general goal for the registrar-agent application is the reuse of 
-		  already defined endpoints of the domain registrar side. The 
-		  functionality of the already existing registrar endpoints may need 
+       <t> To support mutual trust establishment of pledges, not directly
+		  connected to the domain registrar. It relies on the exchange of
+		  authenticated self-contained objects (the voucher request/response
+		  objects as known from BRSKI and the enrollment request/response
+		  objects as introduced by BRSKI-AE). This approach has also been applied
+		  also for the use case 1.
+		  This allows independence of a potential protection provided by the
+		  used transport protocol. </t>
+	  <t> In contrast to BRSKI, the object exchanges performed with the help of
+	      a registrar-agent component, supporting the interaction of
+		  the pledge with the domain registrar. It may be an integrated
+		  functionality of a commissioning tool. This leads to enhancements
+		  of the logical elements in the BRSKI architecture as shown in
+		  <xref target="uc2figure" />.
+		  The registrar-agent interacts with the pledge to acquire and to supply
+		  the required data objects for bootstrapping, which are also exchanged
+		  between the registrar-agent and the domain registrar.
+		  Moreover, the addition of the registrar-agent
+		  also influences the sequences for the data exchange between the pledge
+		  and the domain registrar described in
+		  <xref target="RFC8995" />.
+		  The general goal for the registrar-agent application is the reuse of
+		  already defined endpoints of the domain registrar side. The
+		  functionality of the already existing registrar endpoints may need
 		  small enhancements.</t>
 
 <figure anchor="uc2figure" title="Architecture overview using registrar-agent">
@@ -964,7 +964,7 @@
 |       |     |         |   .                            |        .
 |       |     |         |   .  +-----------+       +-----v-----+  .
 |       |     |Registrar|   .  |           |       |           |  .
-|Pledge |     |Agent    |   .  |   Join    |       | Domain    |  .  
+|Pledge |     |Agent    |   .  |   Join    |       | Domain    |  .
 |       |     |         |   .  |   Proxy   |       | Registrar |  .
 |       <----->.........<------>...........<-------> (PKI RA)  |  .
 |       |     |         |   .  |       BRSKI-AE    |           |  .
@@ -980,297 +980,297 @@
 ]]></artwork>
 </figure>
 
-        <t> The architecture overview in <xref target="uc2figure" /> utilizes 
-		    the same logical components as BRSKI with the registrar-agent 
+        <t> The architecture overview in <xref target="uc2figure" /> utilizes
+		    the same logical components as BRSKI with the registrar-agent
 			component in addition. </t>
-				
-		<t> For authentication towards the domain registrar, the registrar-agent 
-			uses its LDevID. The provisioning of the registrar-agent LDevID may 
-			be done by a separate BRSKI run or other means in advance. It is 
-			recommended to use short lived registrar-agent LDevIDs in the range 
+
+		<t> For authentication towards the domain registrar, the registrar-agent
+			uses its LDevID. The provisioning of the registrar-agent LDevID may
+			be done by a separate BRSKI run or other means in advance. It is
+			recommended to use short lived registrar-agent LDevIDs in the range
 			of days or weeks. </t>
-			
-		<t>	If a registrar detects a request originates from a registrar-agent 
+
+		<t>	If a registrar detects a request originates from a registrar-agent
 		    it is able to switch the operational mode from BRSKI to BRSKI-AE. </t>
-			
-		<t>	In addition, the domain registrar may authenticate the user operating 
-			the registrar-agent to perform additional authorization of a pledge 
-			enrollment action. Examples for such user level authentication are 
-			the application of HTTP authentication or the usage of authorization 
+
+		<t>	In addition, the domain registrar may authenticate the user operating
+			the registrar-agent to perform additional authorization of a pledge
+			enrollment action. Examples for such user level authentication are
+			the application of HTTP authentication or the usage of authorization
 			tokens or other. This is out of scope of this document. </t>
-		    
-		<t> The following list describes the components in a (customer) site domain: 
+
+		<t> The following list describes the components in a (customer) site domain:
 		    <list style="symbols">
-            <t> Pledge: The pledge is expected to respond with the necessary data 
-			    objects for bootstrapping to the registrar-agent. 
-				The transport protocol used between the pledge and the 
-				registrar-agent is assumed to be HTTP in the context of this 
-				document. Other transport protocols may be used but are out of 
-				scope of this document. 
-				As the pledge is acting as a server during bootstrapping it 
+            <t> Pledge: The pledge is expected to respond with the necessary data
+			    objects for bootstrapping to the registrar-agent.
+				The transport protocol used between the pledge and the
+				registrar-agent is assumed to be HTTP in the context of this
+				document. Other transport protocols may be used but are out of
+				scope of this document.
+				As the pledge is acting as a server during bootstrapping it
 				leads to some differences to BRSKI:
 				<list style="symbols">
-                <t> Discovery of the domain registrar by the pledge is not needed 
+                <t> Discovery of the domain registrar by the pledge is not needed
   				    as the pledge will be triggered by the registrar-agent.</t>
-                <t> Discovery of the pledge by the registrar-agent must be 
+                <t> Discovery of the pledge by the registrar-agent must be
 				    possible. </t>
-				<t> As the registrar-agent must be able to request data objects 
-				    for bootstrapping of the pledge, the pledge must offer 
+				<t> As the registrar-agent must be able to request data objects
+				    for bootstrapping of the pledge, the pledge must offer
 					corresponding endpoints. </t>
-				<t> The registrar-agent may provide additional data to the pledge, 
+				<t> The registrar-agent may provide additional data to the pledge,
 				    in the context of the triggering request. </t>
-				<t> Order of exchanges in the call flow may be different as 
-				    the registrar-agent collects both objects, pledge-voucher-request 
-					objects and pledge-enrollment-request objects, at once and provides 
-					them to the registrar. This approach may also be used to 
+				<t> Order of exchanges in the call flow may be different as
+				    the registrar-agent collects both objects, pledge-voucher-request
+					objects and pledge-enrollment-request objects, at once and provides
+					them to the registrar. This approach may also be used to
 					perform a bulk bootstrapping of several devices. </t>
-				<t> The data objects utilized for the data exchange between 
-				    the pledge and the registrar are self-contained authenticated 
-					objects (signature-wrapped objects) as in use case 1 
-					<xref target="uc1" />. </t>	
-			    </list>		
+				<t> The data objects utilized for the data exchange between
+				    the pledge and the registrar are self-contained authenticated
+					objects (signature-wrapped objects) as in use case 1
+					<xref target="uc1" />. </t>
+			    </list>
 			</t>
-				
-            <t> Registrar-agent: provides a communication path to exchange 
-                data objects between the pledge and the domain registrar. 
-				The registrar-agent facilitates situations, in which the domain 
-				registrar is not directly reachable by the pledge, either due 
-				to a different technology stack or due to missing connectivity. 
-				The registrar-agent triggers 
-				the pledge to create bootstrapping information such as voucher 
-				request objects and enrollment request objects from one or 
-				multiple pledges at once and performs a bulk bootstrapping based 
-				on the collected data. 
+
+            <t> Registrar-agent: provides a communication path to exchange
+                data objects between the pledge and the domain registrar.
+				The registrar-agent facilitates situations, in which the domain
+				registrar is not directly reachable by the pledge, either due
+				to a different technology stack or due to missing connectivity.
+				The registrar-agent triggers
+				the pledge to create bootstrapping information such as voucher
+				request objects and enrollment request objects from one or
+				multiple pledges at once and performs a bulk bootstrapping based
+				on the collected data.
 				The registrar-agent is expected to possess information of the
-				domain registrar, either by configuration or by using the 
+				domain registrar, either by configuration or by using the
 				discovery mechanism defined in <xref target="RFC8995" />.
-				There is no trust assumption between the pledge and the 
-				registrar-agent as only authenticated self-contained objects 
-				are applied, which are transported via the registrar-agent and 
-				provided either by the pledge or the registrar. 	
-				The trust assumption between the registrar-agent and the registrar 
-				bases on an own LDevID of the registrar-agent, acting as registrar 
-				component. This allows the registrar-agent to authenticate towards 
-				the registrar. The registrar can utilize this authentication to 
-				distinguish communication with a pledge from a registrar-agent 
+				There is no trust assumption between the pledge and the
+				registrar-agent as only authenticated self-contained objects
+				are applied, which are transported via the registrar-agent and
+				provided either by the pledge or the registrar.
+				The trust assumption between the registrar-agent and the registrar
+				bases on an own LDevID of the registrar-agent, acting as registrar
+				component. This allows the registrar-agent to authenticate towards
+				the registrar. The registrar can utilize this authentication to
+				distinguish communication with a pledge from a registrar-agent
 				based on the exchanged objects.</t>
 
-            <t> Join Proxy: same functionality as described in 
-			    <xref target="RFC8995" />. Note 
-				that it may be used by the registrar-agent instead of the pledge 
+            <t> Join Proxy: same functionality as described in
+			    <xref target="RFC8995" />. Note
+				that it may be used by the registrar-agent instead of the pledge
 				to find the registrar, if not configured.</t>
 
-            <t> Domain Registrar: In general the domain registrar fulfills the 
-			    same functionality regarding the bootstrapping of the pledge in 
-				a (customer) site domain by facilitating the communication of the 
-				pledge with the MASA service and the domain PKI service. In 
-				contrast to 
-				<xref target="RFC8995" />, the 
-				domain registrar does not interact with a pledge directly but 
-				through the registrar-agent. The registrar detects if 
-				the bootstrapping is performed by the pledge directly or by the 
+            <t> Domain Registrar: In general the domain registrar fulfills the
+			    same functionality regarding the bootstrapping of the pledge in
+				a (customer) site domain by facilitating the communication of the
+				pledge with the MASA service and the domain PKI service. In
+				contrast to
+				<xref target="RFC8995" />, the
+				domain registrar does not interact with a pledge directly but
+				through the registrar-agent. The registrar detects if
+				the bootstrapping is performed by the pledge directly or by the
 				registrar-agent.</t>
-		  </list>	 
- 		  
-		 The manufacturer provided components/services (MASA and Ownership 
-		 tracker) are used as defined in <xref target="RFC8995" />. For issuing 
-		 a voucher, the MASA may perform additional checks on voucher-request 
-		 objects, to issue a voucher indicating agent-proximity instead of 
+		  </list>
+
+		 The manufacturer provided components/services (MASA and Ownership
+		 tracker) are used as defined in <xref target="RFC8995" />. For issuing
+		 a voucher, the MASA may perform additional checks on voucher-request
+		 objects, to issue a voucher indicating agent-proximity instead of
 		 registrar-proximity. </t>
-		 
-	 <t> "Agent-proximity" is a weaker assertion then "proximity". 
-	     In case of "agent-proximity" it is a statement, that the 
-		 proximity-registrar-certificate was provided via the registrar-agent 
-		 and not directly. This can be verified by the registrar and also by the 
-		 MASA through voucher-request processing. Note that at the time of 
-		 creating the voucher-request, the pledge cannot verify the 
-		 LDevID(Reg) EE certificate and has no proof-of-possession of the 
-		 corresponding private key for the certificate. Trust handover to the 
-		 domain is established via the "pinned-domain-certificate" in the 
+
+	 <t> "Agent-proximity" is a weaker assertion then "proximity".
+	     In case of "agent-proximity" it is a statement, that the
+		 proximity-registrar-certificate was provided via the registrar-agent
+		 and not directly. This can be verified by the registrar and also by the
+		 MASA through voucher-request processing. Note that at the time of
+		 creating the voucher-request, the pledge cannot verify the
+		 LDevID(Reg) EE certificate and has no proof-of-possession of the
+		 corresponding private key for the certificate. Trust handover to the
+		 domain is established via the "pinned-domain-certificate" in the
 		 voucher. </t>
-		 
-	 <t> In contrast, "proximity" provides a statement, that the pledge was in 
-	     direct contact with the registrar and was able to verify 
-		 proof-of-possession of the private key in the context of the TLS 
-		 handshake. The provisionally accepted LDevID(Reg) EE certificate can 
+
+	 <t> In contrast, "proximity" provides a statement, that the pledge was in
+	     direct contact with the registrar and was able to verify
+		 proof-of-possession of the private key in the context of the TLS
+		 handshake. The provisionally accepted LDevID(Reg) EE certificate can
 		 be verified after the voucher has been processed by the pledge.  </t>
-		 
+
         <section anchor="pledge_ep" title="Behavior of a pledge in pledge-responder-mode">
         <t> In contrast to use case 1 <xref target="uc1" /> the pledge acts as
-		    a server component if data is triggered by the registrar-agent for 
-			the generation of pledge-voucher-request and pledge-enrollment-request 
-			objects as well as for the processing of the response objects and the 
-			generation of status information. 
-			Due to the use of the registrar-agent, the interaction with 
-			the domain registrar is changed as shown in 
-			<xref target="exchangesfig_uc2_1" />.	
-			To enable interaction with the registrar-agent, the pledge provides 
-			endpoints using the BRSKI interface based on the 
-			"/.well-known/brski" URI tree. 
-			The following endpoints are defined for the pledge in this document: 
+		    a server component if data is triggered by the registrar-agent for
+			the generation of pledge-voucher-request and pledge-enrollment-request
+			objects as well as for the processing of the response objects and the
+			generation of status information.
+			Due to the use of the registrar-agent, the interaction with
+			the domain registrar is changed as shown in
+			<xref target="exchangesfig_uc2_1" />.
+			To enable interaction with the registrar-agent, the pledge provides
+			endpoints using the BRSKI interface based on the
+			"/.well-known/brski" URI tree.
+			The following endpoints are defined for the pledge in this document:
 
  			<list style="symbols">
-                <t> /.well-known/brski/pledge-voucher-request: trigger pledge to 
+                <t> /.well-known/brski/pledge-voucher-request: trigger pledge to
 				    create voucher request. It returns the pledge-voucher-request.</t>
-                <t> /.well-known/brski/pledge-enrollment-request: trigger pledge to 
+                <t> /.well-known/brski/pledge-enrollment-request: trigger pledge to
 				    create enrollment request. it returns the pledge-enrollment-request.</t>
-				<t> /.well-known/brski/pledge-voucher: supply MASA provided 
+				<t> /.well-known/brski/pledge-voucher: supply MASA provided
 				    voucher to pledge. It returns the pledge-voucher-status.</t>
-				<t> /.well-known/brski/pledge-enrollment: supply enroll 
-				    response (certificate) to pledge. It returns the 
+				<t> /.well-known/brski/pledge-enrollment: supply enroll
+				    response (certificate) to pledge. It returns the
 					pledge-enrollment-status.</t>
-				<t> /.well-known/brski/pledge-CACerts: supply CACerts to 
+				<t> /.well-known/brski/pledge-CACerts: supply CACerts to
 				    pledge (optional). </t>
-			</list>		
+			</list>
 		</t>
-			 
+
 		</section>
-		
+
 		<section title="Behavior of a registrar-agent">
-        <t> The registrar-agent is a new component in the BRSKI context. It 
-		    provides connectivity between the pledge and the domain registrar 
-			and reuses the endpoints of the domain registrar side already 
+        <t> The registrar-agent is a new component in the BRSKI context. It
+		    provides connectivity between the pledge and the domain registrar
+			and reuses the endpoints of the domain registrar side already
 			specified in <xref target="RFC8995" />.
-			It facilitates the exchange of data objects between the pledge and 
-			the domain registrar, which are the voucher request/response objects, 
-			the enrollment request/response objects, as well as related status 
-			objects. 
-			For the communication the registrar-agent utilizes communication 
-			endpoints provided by the pledge. 
-			The transport in this specification is based on HTTP but may also 
-			be done using other transport mechanisms. This new component changes 
-			the general interaction between the pledge and the domain registrar 
+			It facilitates the exchange of data objects between the pledge and
+			the domain registrar, which are the voucher request/response objects,
+			the enrollment request/response objects, as well as related status
+			objects.
+			For the communication the registrar-agent utilizes communication
+			endpoints provided by the pledge.
+			The transport in this specification is based on HTTP but may also
+			be done using other transport mechanisms. This new component changes
+			the general interaction between the pledge and the domain registrar
 			as shown in <xref target="exchangesfig_uc2_2" />. </t>
-		
-		<t> The registrar-agent is expected to already possess an LDevID(RegAgt) 
-		    to authenticate towards the domain registrar. The registrar-agent 
-			will use this LDevID(RegAgt) when establishing the TLS session 
-			with the domain registrar in the context of for TLS client-side 
-			authentication. The LDevID(RegAgt) certificate MUST include a 
-			SubjectKeyIdentifier (SKID), which is used as reference in the 
-			context of an agent-signed-data object. Note that this is an additional 
+
+		<t> The registrar-agent is expected to already possess an LDevID(RegAgt)
+		    to authenticate towards the domain registrar. The registrar-agent
+			will use this LDevID(RegAgt) when establishing the TLS session
+			with the domain registrar in the context of for TLS client-side
+			authentication. The LDevID(RegAgt) certificate MUST include a
+			SubjectKeyIdentifier (SKID), which is used as reference in the
+			context of an agent-signed-data object. Note that this is an additional
 			requirement for issuing the certificate, as <xref target="IEEE-802.1AR" />
-			only requires the SKID to be included for intermediate CA certificates. 
-			In the specific application of BRSKI-AE, it is used in favor of a 
-			certificate fingerprint to avoid additional computations. </t> 
-		
-		<t> Using an LDevID for TLS client-side authentication is a deviation 
-		    from <xref target="RFC8995" />, 
-			in which the pledge's IDevID credential is used to perform 
-			TLS client authentication. The use of the LDevID(RegAgt) allows the 
-			domain registrar to distinguish, if bootstrapping is initiated from a 
-			pledge or from a registrar-agent and adopt the internal handling 
+			only requires the SKID to be included for intermediate CA certificates.
+			In the specific application of BRSKI-AE, it is used in favor of a
+			certificate fingerprint to avoid additional computations. </t>
+
+		<t> Using an LDevID for TLS client-side authentication is a deviation
+		    from <xref target="RFC8995" />,
+			in which the pledge's IDevID credential is used to perform
+			TLS client authentication. The use of the LDevID(RegAgt) allows the
+			domain registrar to distinguish, if bootstrapping is initiated from a
+			pledge or from a registrar-agent and adopt the internal handling
 			accordingly.
-			As BRSKI-AE uses authenticated self-contained data objects between 
-			the pledge and the domain registrar, the binding of the pledge 
-			identity to the request object is provided by the data object 
-			signature employing the pledge's IDevID. The objects exchanged between 
-			the pledge and the domain registrar used in the context of this 
+			As BRSKI-AE uses authenticated self-contained data objects between
+			the pledge and the domain registrar, the binding of the pledge
+			identity to the request object is provided by the data object
+			signature employing the pledge's IDevID. The objects exchanged between
+			the pledge and the domain registrar used in the context of this
 			specifications are JOSE objects</t>
-			 			 
-		<t> In addition to the LDevID(RegAgt), the registrar-agent is provided 
-		    with the product-serial-numbers of the pledges to be bootstrapped. 
-			This is necessary to allow the discovery of pledges by the 
-			registrar-agent using mDNS. The list may be provided by administrative 
-			means or the registrar agent may get the information via an interaction 
-			with the pledge, like scanning of product-serial-number information 
+
+		<t> In addition to the LDevID(RegAgt), the registrar-agent is provided
+		    with the product-serial-numbers of the pledges to be bootstrapped.
+			This is necessary to allow the discovery of pledges by the
+			registrar-agent using mDNS. The list may be provided by administrative
+			means or the registrar agent may get the information via an interaction
+			with the pledge, like scanning of product-serial-number information
 			using a QR code or similar. </t>
-			
-		<t> According to <xref target="RFC8995" /> section 5.3, the domain 
-		    registrar performs the pledge authorization for bootstrapping within 
+
+		<t> According to <xref target="RFC8995" /> section 5.3, the domain
+		    registrar performs the pledge authorization for bootstrapping within
 			his domain based on the pledge voucher-request object. </t>
-		
+
 		<t> The following information is therefore available at the registrar-agent:
  			<list style="symbols">
                 <t> LDevID(RegAgt): own operational key pair.</t>
                 <t> LDevID(reg) certificate: certificate of the domain registrar.</t>
-				<t> Serial-number(s): product-serial-number(s) of pledge(s) 
+				<t> Serial-number(s): product-serial-number(s) of pledge(s)
 				    to be bootstrapped. </t>
-			</list>		
+			</list>
 		</t>
-	
 
-			<section anchor="discovery_uc2_reg" 
+
+			<section anchor="discovery_uc2_reg"
 				   title="Registrar discovery by the registrar-agent">
-			<t> The discovery of the domain registrar may be done as specified in 
-				<xref target="RFC8995" /> with the 
-				deviation that it is done between the registrar-agent and the domain 
-				registrar. Alternatively, the registrar-agent may be configured 
-				with the address of the domain registrar and the certificate 
+			<t> The discovery of the domain registrar may be done as specified in
+				<xref target="RFC8995" /> with the
+				deviation that it is done between the registrar-agent and the domain
+				registrar. Alternatively, the registrar-agent may be configured
+				with the address of the domain registrar and the certificate
 				of the domain registrar.</t>
 			</section>
-		
+
 			<section anchor="discovery_uc2_ppa"
 				   title="Pledge discovery by the registrar-agent">
-			<t>	The discovery of the pledge by registrar-agent should be done 
-			    by using DNS-based Service Discovery <xref target="RFC6763" /> 
-				over Multicast DNS <xref target="RFC6762" /> to discover the 
+			<t>	The discovery of the pledge by registrar-agent should be done
+			    by using DNS-based Service Discovery <xref target="RFC6763" />
+				over Multicast DNS <xref target="RFC6762" /> to discover the
 				pledge at “product-serial-number.brski-pledge._tcp.local.”
 
-				The pledge constructs a local host name based on device local 
-				information (product-serial-number), which results in 
-				"product-serial-number.brski-pledge._tcp.local.". It can then be 
-				discovered by the registrar-agent via mDNS. Note that other 
-				mechanisms for discovery may be used.</t>	
-				
-			<t> The registrar-agent is able to build the same information based 
+				The pledge constructs a local host name based on device local
+				information (product-serial-number), which results in
+				"product-serial-number.brski-pledge._tcp.local.". It can then be
+				discovered by the registrar-agent via mDNS. Note that other
+				mechanisms for discovery may be used.</t>
+
+			<t> The registrar-agent is able to build the same information based
 			    on the provided list of product-serial-number. </t>
 			</section>
-			
+
 		</section>
-		
-        <section anchor="exchanges_uc2" title="Bootstrapping objects and corresponding exchanges">			
-	    <t> The interaction of the pledge with the registrar-agent may be 
-		    accomplished using different transport means (protocols and or 
-			network technologies). For this document the usage of HTTP is 
-			targeted as in BRSKI. Alternatives may be CoAP, Bluetooth Low 
-			Energy (BLE), or Nearfield Communication (NFC). This requires 
-			independence of the exchanged data objects between the pledge and 
-			the registrar from transport security. Therefore, authenticated 
-			self-contained objects (here: signature-wrapped objects) are applied 
+
+        <section anchor="exchanges_uc2" title="Bootstrapping objects and corresponding exchanges">
+	    <t> The interaction of the pledge with the registrar-agent may be
+		    accomplished using different transport means (protocols and or
+			network technologies). For this document the usage of HTTP is
+			targeted as in BRSKI. Alternatives may be CoAP, Bluetooth Low
+			Energy (BLE), or Nearfield Communication (NFC). This requires
+			independence of the exchanged data objects between the pledge and
+			the registrar from transport security. Therefore, authenticated
+			self-contained objects (here: signature-wrapped objects) are applied
 			in the data exchange between the pledge and the registrar.  </t>
-			
-		<t>	The registrar-agent provides the domain-registrar certificate 
-		    (LDevID(Reg) EE certificate) to the pledge to be included into 
-			the "agent-provided-proximity-registrar-certificate" leaf in the 
-			pledge-voucher-request object. This enables the registrar to verify, 
-			that it is the target registrar for handling the request. The registrar 
-			certificate may be configured at the registrar-agent or may be 
-			fetched by the registrar-agent based on a prior TLS connection 
-			establishment with the domain registrar. 
-			In addition, the registrar-agent provides agent-signed-data containing 
-			the product-serial-number in the body, signed with the LDevID(RegAgt). 
-			This enables the registrar to verify and log, which registrar-agent was 
-			in contact with the pledge. 
-			Optionally the registrar-agent may provide its LDevID(RegAgt) 
-			certificate to the pledge for inclusion into the pledge-voucher-request 
-			as "agent-sign-cert" leaf. 
-			Note that this may be omitted in constraint environments to safe 
-			bandwidth between the registrar-agent and the pledge. 
-			If not contained, the registrar-agent MUST fetch the LDevID(RegAgt) 
-			certificate based on the SubjectKeyIdentifier (SKID) in the header 
-			of the agent-signed-data. The registrar may include the LDevID(RegAgt) 
+
+		<t>	The registrar-agent provides the domain-registrar certificate
+		    (LDevID(Reg) EE certificate) to the pledge to be included into
+			the "agent-provided-proximity-registrar-certificate" leaf in the
+			pledge-voucher-request object. This enables the registrar to verify,
+			that it is the target registrar for handling the request. The registrar
+			certificate may be configured at the registrar-agent or may be
+			fetched by the registrar-agent based on a prior TLS connection
+			establishment with the domain registrar.
+			In addition, the registrar-agent provides agent-signed-data containing
+			the product-serial-number in the body, signed with the LDevID(RegAgt).
+			This enables the registrar to verify and log, which registrar-agent was
+			in contact with the pledge.
+			Optionally the registrar-agent may provide its LDevID(RegAgt)
+			certificate to the pledge for inclusion into the pledge-voucher-request
+			as "agent-sign-cert" leaf.
+			Note that this may be omitted in constraint environments to safe
+			bandwidth between the registrar-agent and the pledge.
+			If not contained, the registrar-agent MUST fetch the LDevID(RegAgt)
+			certificate based on the SubjectKeyIdentifier (SKID) in the header
+			of the agent-signed-data. The registrar may include the LDevID(RegAgt)
 			certificate information into the registrar-voucher-request. </t>
-		
-		<t> The MASA in turn verifies the LDevID(Reg) certificate is included  
-		    in the pledge-voucher-request (prior-signed-voucher-request) in the 
-			"agent-provided-proximity-registrar-certificate" leaf and may assert 
-			in the voucher "verified" or "logged" 
-			instead of "proximity", as there is no direct connection between the 
+
+		<t> The MASA in turn verifies the LDevID(Reg) certificate is included
+		    in the pledge-voucher-request (prior-signed-voucher-request) in the
+			"agent-provided-proximity-registrar-certificate" leaf and may assert
+			in the voucher "verified" or "logged"
+			instead of "proximity", as there is no direct connection between the
 			pledge and the registrar.
-			If the LDevID(RegAgt) certificate is included contained in the "agent-sign-cert" 
-			leave of the registrar-voucher-request, the MASA can verify the 
-			LDevID(RegAgt) certificate and the signature of the registrar-agent 
-			in the agent-signed-data provided in the prior-signed-voucher-request. 
-			If both can be verified successfully, the MASA can assert 
-			"agent-proximity" in the voucher. Otherwise, it may assert "verified" 
-			or "logged". The voucher can then be supplied via the registrar 
+			If the LDevID(RegAgt) certificate is included contained in the "agent-sign-cert"
+			leave of the registrar-voucher-request, the MASA can verify the
+			LDevID(RegAgt) certificate and the signature of the registrar-agent
+			in the agent-signed-data provided in the prior-signed-voucher-request.
+			If both can be verified successfully, the MASA can assert
+			"agent-proximity" in the voucher. Otherwise, it may assert "verified"
+			or "logged". The voucher can then be supplied via the registrar
 			to the registrar-agent. </t>
-			
-		<t> <xref target="exchangesfig_uc2_all" /> provides an overview of 
+
+		<t> <xref target="exchangesfig_uc2_all" /> provides an overview of
 		    the exchanges detailed in the following sub sections. </t>
-			
-			
+
+
 <figure anchor="exchangesfig_uc2_all" title="Overview pledge-responder-mode exchanges">
 <artwork name="" type="" align="left" alt=""><![CDATA[
 +--------+  +-----------+    +-----------+   +--------+   +---------+
@@ -1278,7 +1278,7 @@
 |        |  | Agent     |    | Registrar |   | CA     |   | Service |
 |        |  | (RegAgt)  |    |  (JRC)    |   |        |   | (MASA)  |
 +--------+  +-----------+    +-----------+   +--------+   +---------+
-     |              |                  |              |   Internet | 
+     |              |                  |              |   Internet |
 [discovery of pledge]
      | mDNS query   |                  |              |            |
      |<-------------|                  |              |            |
@@ -1303,20 +1303,20 @@
      |              |                  |<-------- Voucher ---------|
      |              |<---- Voucher ----|              |            |
      |              |                  |              |            |
-[provide pledge enrollment request to infrastructure]        
+[provide pledge enrollment request to infrastructure]
      |              |-- Enroll-Req --->|              |            |
      |              |                  |- Cert-Req -->|            |
      |              |                  |<-Certificate-|            |
      |              |<-- Enroll-Resp --|              |            |
      ~              ~                  ~              ~            ~
-[provide voucher and certificate 
+[provide voucher and certificate
  to pledge and collect status info]
      |<-- Voucher --|                  |              |            |
      |-- vStatus -->|                  |              |            |
      |<-Enroll-Resp-|                  |              |            |
      |-- eStatus -->|                  |              |            |
      ~              ~                  ~              ~            ~
-[provide voucher-status and enrollment status to registrar]        
+[provide voucher-status and enrollment status to registrar]
      |              |<------ TLS ----->|              |            |
      |              |----  vStatus --->|              |            |
      |              |                  |-- req. device audit log ->|
@@ -1326,133 +1326,133 @@
      |              |----  eStatus --->|              |            |
      |              |                  |              |            |
 ]]></artwork>
-</figure>		
+</figure>
 
-		<t> The following sub sections split the interactions between the different 
+		<t> The following sub sections split the interactions between the different
 		    components into: </t>
-		<t> <list style="symbols"> 
-				<t> Request objects acquisition targets exchanges and objects between 
+		<t> <list style="symbols">
+				<t> Request objects acquisition targets exchanges and objects between
 				    the registrar-agent and the pledge.</t>
-				<t> Request handling targets exchanges and objects between 
-				    the registrar-agent and the registrar and also the interaction 
-					of the registrar with the MASA and the domain CA.</t>				
-				<t> Response object supply targets the exchanges and objects between 
-				    the registrar-agent and the pledge including the status 
+				<t> Request handling targets exchanges and objects between
+				    the registrar-agent and the registrar and also the interaction
+					of the registrar with the MASA and the domain CA.</t>
+				<t> Response object supply targets the exchanges and objects between
+				    the registrar-agent and the pledge including the status
 					objects.</t>
-				<t> Status handling addresses the exchanges between the 
+				<t> Status handling addresses the exchanges between the
 				    registrar-agent and the registrar. </t>
 			</list> </t>
-		
-	
+
+
  	    <section anchor="exchanges_uc2_1" title=" Request objects acquisition (registrar-agent - pledge)">
-		
-	    <t> The following description assumes that the registrar-agent already 
-		    discovered the pledge. This may be done as described in 
+
+	    <t> The following description assumes that the registrar-agent already
+		    discovered the pledge. This may be done as described in
 			<xref target="discovery_uc2_ppa" /> based on mDNS. </t>
-		
-		<t> The focus is on the exchange of signature-wrapped objects using 
-			endpoints defined for the pledge in <xref target="pledge_ep" />.</t>		
-			
+
+		<t> The focus is on the exchange of signature-wrapped objects using
+			endpoints defined for the pledge in <xref target="pledge_ep" />.</t>
+
 		<t> Preconditions: </t>
-		<t> <list style="symbols"> 
+		<t> <list style="symbols">
 				<t> Pledge: possesses IDevID </t>
-				<t> Registrar-agent: possesses IDevID CA certificate and an own 
-				    LDevID(RegAgt) EE credential for the registrar domain. In addition, 
-					the registrar-agent can be configured with the 
-					product-serial-number(s) of the pledge(s) to be bootstrapped. 
-					Note that the product-serial-number may have been used during 
+				<t> Registrar-agent: possesses IDevID CA certificate and an own
+				    LDevID(RegAgt) EE credential for the registrar domain. In addition,
+					the registrar-agent can be configured with the
+					product-serial-number(s) of the pledge(s) to be bootstrapped.
+					Note that the product-serial-number may have been used during
 					the pledge discovery already. </t>
-				<t> Registrar: possesses IDevID CA certificate and an own 
+				<t> Registrar: possesses IDevID CA certificate and an own
 				    LDevID/Reg) credential.</t>
-				<t> MASA: possesses own credentials (voucher signing key, TLS 
-				    server certificate) as well as IDevID CA certificate of pledge 
+				<t> MASA: possesses own credentials (voucher signing key, TLS
+				    server certificate) as well as IDevID CA certificate of pledge
 					vendor / manufacturer and site-specific LDevID CA certificate.</t>
 			</list> </t>
-	
-			
+
+
 <figure anchor="exchangesfig_uc2_1" title="Request collection (registrar-agent - pledge)">
 <artwork name="" type="" align="left" alt=""><![CDATA[
-+--------+                        +-----------+   
-| Pledge |                        | Registrar |   
-|        |                        | Agent     |   
-|        |                        | (RegAgt)  |   
-+--------+                        +-----------+   
-    |                                   | - create       
++--------+                        +-----------+
+| Pledge |                        | Registrar |
+|        |                        | Agent     |
+|        |                        | (RegAgt)  |
++--------+                        +-----------+
+    |                                   | - create
     |                                   |   agent-signed-data
-    |<- trigger pledge-voucher-request -|       
-    |   - proximity-registrar-cert      |       
-    |   - agent-signed-data             |       
-    |   - agent-sign-cert (optional)    |       
-    |                                   |                
-    |---- pledge-voucher-request ------>| - store   
-    |                                   |   pledge-voucher-request   
-    |<--- trigger enrollment request ---|       
-    |     (empty)                       |       
-    |                                   | 
-    |---- pledge-enrollment-request --->| - store       
-    |                                   |   pledge-enrollment-request    
+    |<- trigger pledge-voucher-request -|
+    |   - proximity-registrar-cert      |
+    |   - agent-signed-data             |
+    |   - agent-sign-cert (optional)    |
+    |                                   |
+    |---- pledge-voucher-request ------>| - store
+    |                                   |   pledge-voucher-request
+    |<--- trigger enrollment request ---|
+    |     (empty)                       |
+    |                                   |
+    |---- pledge-enrollment-request --->| - store
+    |                                   |   pledge-enrollment-request
 ]]></artwork>
 </figure>
 
 
-		<t>	Triggering the pledge to create the pledge-voucher-request is done using 
-		    HTTPS POST on the defined pledge endpoint 
+		<t>	Triggering the pledge to create the pledge-voucher-request is done using
+		    HTTPS POST on the defined pledge endpoint
             "/.well-known/brski/pledge-voucher-request". </t>
-			
+
         <t> The registrar-agent pledge-voucher-request Content-Type header is:</t>
-		
+
         <t> application/json: defines a JSON document to provide three parameter:
 			<list style="symbols">
-                <t> proximity-registrar-cert: base64-encoded LDevID(Reg) (D) 
+                <t> proximity-registrar-cert: base64-encoded LDevID(Reg) (D)
 				    TLS EE certificate.</t>
-                <t> agent-sign-cert: base64-encoded LDevID(RegAgt) signing 
+                <t> agent-sign-cert: base64-encoded LDevID(RegAgt) signing
 				    certificate (optional).</t>
 				<t> agent-signed-data: base64-encoded JWS-object. </t>
 			</list>	</t>
-			
-        <t> Note that optionally including the agent-sign-cert enables the pledge 
-		    to verify at least the signature of the agent-signed-data. It may 
-			not verify the agent-sign-cert itself due to missing issuing CA 
+
+        <t> Note that optionally including the agent-sign-cert enables the pledge
+		    to verify at least the signature of the agent-signed-data. It may
+			not verify the agent-sign-cert itself due to missing issuing CA
             information. </t>
-		
-		<t> The agent-signed-data is JOSE object and contains the following 
+
+		<t> The agent-signed-data is JOSE object and contains the following
 		    information:</t>
 
 		<t> The header of the agent-signed-data contains:
 			<list style="symbols">
                 <t> alg: algorithm used for creating the object signature.</t>
-                <t> kid: contains the base64-encoded SubjectKeyIdentifier of the 
+                <t> kid: contains the base64-encoded SubjectKeyIdentifier of the
 				    LDevID(RegAgt) certificate.</t>
 			</list>	</t>
-		<t> The body of the agent-signed-data contains an 
+		<t> The body of the agent-signed-data contains an
 		    ietf-voucher-request-trigger:agent-signed-data element:	</t>
-			
+
 		<t> [RFC Editor: please delete] /* </t>
-		<t> Open Issue regarding YANG Definition. Is either definition of 
-		    ietf-voucher-request-trigger:agent-signed-data as new module or 
-			ietf-voucher-request:agent-signed-data as new leaf in the existing 
-			module necessary or would it be sufficient to just keep the 
+		<t> Open Issue regarding YANG Definition. Is either definition of
+		    ietf-voucher-request-trigger:agent-signed-data as new module or
+			ietf-voucher-request:agent-signed-data as new leaf in the existing
+			module necessary or would it be sufficient to just keep the
 			product-serial-number and the date?*/ </t>
-			
+
 		<t>	<list style="symbols">
-                <t> created-on: MUST contain the creation date and time 
+                <t> created-on: MUST contain the creation date and time
 				    in yang:date-and-time format.</t>
-                <t> serial-number: MUST contain the product-serial-number 
-				    as type string as defined in <xref target="RFC8995" />, 
-					section 2.3.1. The serial-number corresponds with the 
-					product-serial-number contained in the X520SerialNumber field 
+                <t> serial-number: MUST contain the product-serial-number
+				    as type string as defined in <xref target="RFC8995" />,
+					section 2.3.1. The serial-number corresponds with the
+					product-serial-number contained in the X520SerialNumber field
 					of the IDevID certificate of the pledge. </t>
 			</list>	</t>
 <figure anchor="asd" title=" Example of agent-signed-data">
 <artwork name="" type="" align="left" alt=""><![CDATA[
 {
-    "alg": "ES256", 
-    "kid": "base64encodedvalue=="      
+    "alg": "ES256",
+    "kid": "base64encodedvalue=="
 }
 {
-  "ietf-voucher-request-trigger:agent-signed-data": { 
-    "created-on": "2021-04-16T00:00:01.000Z",         
-    "serial-number": "callee4711"                    
+  "ietf-voucher-request-trigger:agent-signed-data": {
+    "created-on": "2021-04-16T00:00:01.000Z",
+    "serial-number": "callee4711"
   }
 }
 {
@@ -1461,53 +1461,53 @@
 ]]></artwork>
 </figure>
 
-		<t> Upon receiving the voucher-request trigger, the pledge SHOULD 
-		    construct the body of the pledge-voucher-request object as defined in 
-			<xref target="RFC8995" />. This object 
-			becomes a JSON-in-JWS object as defined in 
-			<xref target="I-D.richardson-anima-jose-voucher" />. </t>		
-		
-		<t> The header of the pledge-voucher-request SHALL contain the following 
+		<t> Upon receiving the voucher-request trigger, the pledge SHOULD
+		    construct the body of the pledge-voucher-request object as defined in
+			<xref target="RFC8995" />. This object
+			becomes a JSON-in-JWS object as defined in
+			<xref target="I-D.richardson-anima-jose-voucher" />. </t>
+
+		<t> The header of the pledge-voucher-request SHALL contain the following
 		    parameter as defined in <xref target="RFC7515" />:
 			<list style="symbols">
                 <t>alg: algorithm used for creating the object signature.</t>
-                <t>x5c: contains the base64-encoded pledge IDevID certificate. </t>			
+                <t>x5c: contains the base64-encoded pledge IDevID certificate. </t>
 			</list>	</t>
 
-		<t> The body of the pledge-voucher-request object MUST contain the 
-		    following parameter as part of the ietf-voucher-request:voucher as 
+		<t> The body of the pledge-voucher-request object MUST contain the
+		    following parameter as part of the ietf-voucher-request:voucher as
 			defined in <xref target="RFC8995" />:
 			<list style="symbols">
-                <t>created-on: contains the current date and time in 
+                <t>created-on: contains the current date and time in
 				    yang:date-and-time format.</t>
-                <t>nonce: contains a cryptographically strong random or 
+                <t>nonce: contains a cryptographically strong random or
 				    pseudo-random number. </t>
-				<t>serial-number: contains the base64-encoded pledge 
+				<t>serial-number: contains the base64-encoded pledge
 				   product-serial-number.</t>
 				<t>assertion: contains the requested voucher assertion.</t>
 			</list>	</t>
-			
+
 		<t> The ietf-voucher-request:voucher is enhanced with additional parameters:
 			<list style="symbols">
-                <t>agent-provided-proximity-registrar-cert: MUST be included and 
-				    contains the base64-encoded LDevID(Reg) EE certificate  
+                <t>agent-provided-proximity-registrar-cert: MUST be included and
+				    contains the base64-encoded LDevID(Reg) EE certificate
 					(provided as trigger parameter by the registrar-agent).</t>
-                <t>agent-signed-data: MUST contain the base64-encoded 
+                <t>agent-signed-data: MUST contain the base64-encoded
 				    agent-signed-data (as defined in <xref target="asd" />)
 					and provided as trigger parameter. </t>
-				<t>agent-sign-cert: May contain the base64-encoded LDevID(RegAgt) 
+				<t>agent-sign-cert: May contain the base64-encoded LDevID(RegAgt)
 				   EE certificate if provided as trigger parameter.</t>
 			</list>	</t>
-					
-			
-		<t>	The object is signed using the pledges IDevID credential contained 
+
+
+		<t>	The object is signed using the pledges IDevID credential contained
 		    as x5c parameter of the JOSE header. </t>
 
 <figure anchor="pvr" title="Example of pledge-voucher-request">
 <artwork name="" type="" align="left" alt=""><![CDATA[
 {
-   "alg": "ES256", 
-   "x5c": ["MIIB2jCC...dA=="] 
+   "alg": "ES256",
+   "x5c": ["MIIB2jCC...dA=="]
 }
 {
   "ietf-voucher-request:voucher": {
@@ -1515,108 +1515,108 @@
    "nonce": "eDs++/FuDHGUnRxN3E14CQ==",
    "serial-number": "callee4711",
    "assertion": "agent-proximity",
-   "agent-provided-proximity-registrar-cert": "base64encodedvalue==", 
-   "agent-signed-data": "base64encodedvalue==",  
-   "agent-sign-cert": "base64encodedvalue=="     
+   "agent-provided-proximity-registrar-cert": "base64encodedvalue==",
+   "agent-signed-data": "base64encodedvalue==",
+   "agent-sign-cert": "base64encodedvalue=="
   }
 }
 {
     SIGNATURE
 }
 ]]></artwork>
-</figure>		
+</figure>
 
 		<t>	The pledge-voucher-request Content-Type is defined in
 		   <xref target="I-D.richardson-anima-jose-voucher" /> as: </t>
 		<t> application/voucher-jose+json</t>
-		
-		<t>	The pledge SHOULD include an "Accept" header field indicating the 
-		    acceptable media type for the voucher response. The media type 
-			"application/voucher-jose+json" is defined in 
-			<xref target="I-D.richardson-anima-jose-voucher" />. </t> 
-	
-		<t>	Once the registrar-agent has received the pledge-voucher-request 
-		    it can trigger the pledge to generate an enrollment-request object. 
-			As in BRSKI the enrollment request object is a PKCS#10, 
+
+		<t>	The pledge SHOULD include an "Accept" header field indicating the
+		    acceptable media type for the voucher response. The media type
+			"application/voucher-jose+json" is defined in
+			<xref target="I-D.richardson-anima-jose-voucher" />. </t>
+
+		<t>	Once the registrar-agent has received the pledge-voucher-request
+		    it can trigger the pledge to generate an enrollment-request object.
+			As in BRSKI the enrollment request object is a PKCS#10,
 			additionally signed by the IDevID.
-			Note, as the initial enrollment aims to request a general certificate, 
+			Note, as the initial enrollment aims to request a general certificate,
 			no certificate attributes are provided to the pledge. </t>
-			
-		<t>	Triggering the pledge to create the enrollment-request is done using 
-		    HTTPS GET on the defined pledge endpoint 
+
+		<t>	Triggering the pledge to create the enrollment-request is done using
+		    HTTPS GET on the defined pledge endpoint
             "/.well-known/brski/pledge-enrollment-request". </t>
-				
-        <t> The registrar-agent pledge-enrollment-request Content-Type header 
+
+        <t> The registrar-agent pledge-enrollment-request Content-Type header
 		    is:</t>
 		<t> application/json: </t>
 		<t> with an empty body. </t>
-		
-		<t>	Upon receiving the enrollment-trigger, the pledge SHALL construct 
-		    the pledge-enrollment-request as authenticated self-contained object. 
-			The CSR already assures proof of possession of the private key 
-			corresponding to the contained public key. In addition, based on the 
-			additional signature using the IDevID, proof of identity is provided. 
-			Here, a JOSE object is being created in which the body utilizes 
-			the YANG module for the CSR as defined in 
+
+		<t>	Upon receiving the enrollment-trigger, the pledge SHALL construct
+		    the pledge-enrollment-request as authenticated self-contained object.
+			The CSR already assures proof of possession of the private key
+			corresponding to the contained public key. In addition, based on the
+			additional signature using the IDevID, proof of identity is provided.
+			Here, a JOSE object is being created in which the body utilizes
+			the YANG module for the CSR as defined in
 			<xref target="I-D.ietf-netconf-sztp-csr" />. </t>
-		
-		<t> Depending on the capability of the pledge, it MAY construct the 
-		    enrollment request as plain PKCS#10.  
-			Note that the focus here is placed on PKCS#10 as PKCS#10 can be 
-			transmitted in different enrollment protocols like EST, CMP, CMS, 
-			and SCEP. If the pledge is already implementing an enrollment 
-			protocol, it may leverage that functionality for the creation of 
-			the enrollment request object. Note also that 
-			<xref target="I-D.ietf-netconf-sztp-csr" /> also allows for inclusion 
+
+		<t> Depending on the capability of the pledge, it MAY construct the
+		    enrollment request as plain PKCS#10.
+			Note that the focus here is placed on PKCS#10 as PKCS#10 can be
+			transmitted in different enrollment protocols like EST, CMP, CMS,
+			and SCEP. If the pledge is already implementing an enrollment
+			protocol, it may leverage that functionality for the creation of
+			the enrollment request object. Note also that
+			<xref target="I-D.ietf-netconf-sztp-csr" /> also allows for inclusion
 			of certificate request objects from CMP or CMC. </t>
-			
-		<t>	The pledge SHOULD construct the pledge-enrollment-request as PKCS#10 
-		    object and sign it additionally with its IDevID credential. The 
+
+		<t>	The pledge SHOULD construct the pledge-enrollment-request as PKCS#10
+		    object and sign it additionally with its IDevID credential. The
 			pledge-enrollment-request should be encoded as JOSE object. </t>
-			
-		<t> [RFC Editor: please delete] /* 
-		    Open Issues: Depending on target environment, it may be useful to 
-		    assume that the pledge may already "know" its functional scope and 
-			therefore the number of certificates needed during operation. As a 
-			result, multiple CSRs may be generated to provide achieve multiple 
-			certificates as a result of the enrollment. This would need further 
-			description and potential enhancements also in the enrollment-request 
+
+		<t> [RFC Editor: please delete] /*
+		    Open Issues: Depending on target environment, it may be useful to
+		    assume that the pledge may already "know" its functional scope and
+			therefore the number of certificates needed during operation. As a
+			result, multiple CSRs may be generated to provide achieve multiple
+			certificates as a result of the enrollment. This would need further
+			description and potential enhancements also in the enrollment-request
 			object to transport different CSRs. */ </t>
-			
-        <t>	<xref target="I-D.ietf-netconf-sztp-csr" /> considers PKCS#10 but 
-		    also CMP and CMC as certificate request format. Note that the wrapping 
-			signature is only necessary for plain PKCS#10 as other request formats 
-			like CMP and CMS support the signature wrapping as part of their own 
+
+        <t>	<xref target="I-D.ietf-netconf-sztp-csr" /> considers PKCS#10 but
+		    also CMP and CMC as certificate request format. Note that the wrapping
+			signature is only necessary for plain PKCS#10 as other request formats
+			like CMP and CMS support the signature wrapping as part of their own
 			certificate request format. </t>
-			
-		<t> The registrar-agent enrollment-request Content-Type header for a 
+
+		<t> The registrar-agent enrollment-request Content-Type header for a
 		    wrapped PKCS#10 is:</t>
-		
+
         <t> application/jose: </t>
 
-		<t> The header of the pledge enrollment-request SHALL contain the following 
+		<t> The header of the pledge enrollment-request SHALL contain the following
 		    parameter as defined in <xref target="RFC7515" />:
 			<list style="symbols">
                 <t>alg: algorithm used for creating the object signature.</t>
-                <t>x5c: contains the base64-encoded pledge IDevID certificate. </t>			
+                <t>x5c: contains the base64-encoded pledge IDevID certificate. </t>
 			</list>	</t>
 
-		<t> The body of the pledge enrollment-request object SHOULD contain a P10 
-		    parameter (for PKCS#10) as defined for ietf-sztp-csr:csr in 
+		<t> The body of the pledge enrollment-request object SHOULD contain a P10
+		    parameter (for PKCS#10) as defined for ietf-sztp-csr:csr in
 			<xref target="I-D.ietf-netconf-sztp-csr" />:
 			<list style="symbols">
                 <t>P10: contains the base64-encoded PKCS#10 of the pledge.</t>
 			</list>	</t>
-											
-		<t>	The JOSE object is signed using the pledge's IDevID credential, which 
+
+		<t>	The JOSE object is signed using the pledge's IDevID credential, which
 		    corresponds to the certificate signaled in the JOSE header. </t>
 
-			
+
 <figure anchor="per" title="Example of pledge-enrollment-request">
 <artwork name="" type="" align="left" alt=""><![CDATA[
 {
-    "alg": "ES256", 
-    "x5c": ["MIIB2jCC...dA=="]  
+    "alg": "ES256",
+    "x5c": ["MIIB2jCC...dA=="]
 }
 {
   "ietf-sztp-csr:csr": {
@@ -1627,51 +1627,51 @@
     SIGNATURE
 }
 ]]></artwork>
-</figure>		
-			
-		<t> With the collected pledge-voucher-request object and the 
-		    pledge-enrollment-request object, the registrar-agent starts the 
+</figure>
+
+		<t> With the collected pledge-voucher-request object and the
+		    pledge-enrollment-request object, the registrar-agent starts the
 			interaction with the domain registrar. </t>
-		
+
 		<t> [RFC Editor: please delete] /* </t>
 		<t> Open Issues: further description necessary at least for */ </t>
 		<t> <list style="symbols">
-				<t> Values to be taken from the IDevID into the PKCS#10 
-				    (like product-serial-number or subjectName, or certificate 
+				<t> Values to be taken from the IDevID into the PKCS#10
+				    (like product-serial-number or subjectName, or certificate
 					template) </t>
 			</list> </t>
-		
-	    <t> Once the registrar-agent has collected the pledge-voucher-request and 
-		    pledge-enrollment-request objects, it connects to the registrar 
-			and sends the request objects. As the registrar-agent is intended 
-			to work between the pledge and the domain registrar, a collection 
-			of requests from more than one pledges is possible, allowing a bulk 
-			bootstrapping of multiple pledges using the same connection between 
+
+	    <t> Once the registrar-agent has collected the pledge-voucher-request and
+		    pledge-enrollment-request objects, it connects to the registrar
+			and sends the request objects. As the registrar-agent is intended
+			to work between the pledge and the domain registrar, a collection
+			of requests from more than one pledges is possible, allowing a bulk
+			bootstrapping of multiple pledges using the same connection between
 			the registrar-agent and the domain registrar. </t>
 		</section>
 
  	    <section anchor="exchanges_uc2_2" title="Request handling (registrar-agent - infrastructure)">
-		<t> The bootstrapping exchange between the registrar-agent and the domain 
-			registrar resembles the exchanges between the pledge and the domain 
+		<t> The bootstrapping exchange between the registrar-agent and the domain
+			registrar resembles the exchanges between the pledge and the domain
 			registrar from BRSKI in the pledge-initiator-mode with some deviations. </t>
-			
+
 		<t> Preconditions: </t>
-		<t> <list style="symbols"> 
-				<t> Registrar-agent: possesses IDevID CA certificate and own 
-				    LDevID(RegAgt) EE credential of registrar domain. It knows the 
-					address of the domain registrar through configuration or 
-					discovery by, e.g., mDNS/DNSSD. The registrar-agent has 
-					acquired pledge-voucher-request and pledge-enrollment-request 
+		<t> <list style="symbols">
+				<t> Registrar-agent: possesses IDevID CA certificate and own
+				    LDevID(RegAgt) EE credential of registrar domain. It knows the
+					address of the domain registrar through configuration or
+					discovery by, e.g., mDNS/DNSSD. The registrar-agent has
+					acquired pledge-voucher-request and pledge-enrollment-request
 					objects(s). </t>
 				<t> Registrar: possesses IDevID CA certificate of pledge vendors
 				    / manufacturers and an own LDevID(Reg) EE credential.</t>
-				<t> MASA: possesses own credentials (voucher signing key, TLS 
-				    server certificate) as well as IDevID CA certificate of 
-					pledge vendor / manufacturer and site-specific LDevID CA 
+				<t> MASA: possesses own credentials (voucher signing key, TLS
+				    server certificate) as well as IDevID CA certificate of
+					pledge vendor / manufacturer and site-specific LDevID CA
 					certificate.</t>
 			</list> </t>
-	
-<figure anchor="exchangesfig_uc2_2" title="Request processing between 
+
+<figure anchor="exchangesfig_uc2_2" title="Request processing between
 registrar-agent and infrastructure bootstrapping services">
 <artwork name="" type="" align="left" alt=""><![CDATA[
 +-----------+    +-----------+   +--------+   +---------+
@@ -1679,7 +1679,7 @@ registrar-agent and infrastructure bootstrapping services">
 | Agent     |    | Registrar |   | CA     |   | Service |
 | (RegAgt)  |    |  (JRC)    |   |        |   | (MASA)  |
 +-----------+    +-----------+   +--------+   +---------+
-    |                  |              |   Internet | 
+    |                  |              |   Internet |
 [exchange between pledge and ]
 [registrar-agent done. ]
     |                  |              |            |
@@ -1694,8 +1694,8 @@ registrar-agent and infrastructure bootstrapping services">
     |                  |                   [update audit log]
     |<---- Voucher ----|<-------- Voucher ---------|
     |                  |              |            |
-[certification request handling registrar-agent] 
-[and site infrastructure]        
+[certification request handling registrar-agent]
+[and site infrastructure]
     |--- Enroll-Req -->|              |            |
     |                  |---- TLS ---->|            |
     |                  |- Enroll-Req->|            |
@@ -1705,126 +1705,126 @@ registrar-agent and infrastructure bootstrapping services">
 ]]></artwork>
 </figure>
 
-		<t> The registrar-agent establishes a TLS connection with the 
-		    registrar. As already stated in 
-		    <xref target="RFC8995" />, the use 
-		    of TLS 1.3 (or newer) is encouraged.  TLS 1.2 or newer is REQUIRED 
+		<t> The registrar-agent establishes a TLS connection with the
+		    registrar. As already stated in
+		    <xref target="RFC8995" />, the use
+		    of TLS 1.3 (or newer) is encouraged.  TLS 1.2 or newer is REQUIRED
 		    on the registrar-agent side.  TLS 1.3 (or newer) SHOULD be available
             on the registrar, but TLS 1.2 MAY be used.  TLS 1.3 (or newer) SHOULD be
 		    available on the MASA, but TLS 1.2 MAY be used. </t>
-		
+
 		<t> In contrast to <xref target="RFC8995" />
-            client authentication is achieved by using the LDevID(RegAgt) of the 
-			registrar-agent instead of the IDevID of the pledge. This allows 
-			the registrar to distinguish between pledge-initiator-mode and 
-			pledge-responder-mode. In pledge-responder-mode the registrar 
-			has no direct connection to the pledge but via the registrar-agent. 
-			The registrar can receive request objects in different forms as defined in 
-			<xref target="RFC8995" />. Specifically, 
-			the registrar will receive JOSE objects from the pledge for 
-			voucher-request and enrollment-request (instead of the objects for 
+            client authentication is achieved by using the LDevID(RegAgt) of the
+			registrar-agent instead of the IDevID of the pledge. This allows
+			the registrar to distinguish between pledge-initiator-mode and
+			pledge-responder-mode. In pledge-responder-mode the registrar
+			has no direct connection to the pledge but via the registrar-agent.
+			The registrar can receive request objects in different forms as defined in
+			<xref target="RFC8995" />. Specifically,
+			the registrar will receive JOSE objects from the pledge for
+			voucher-request and enrollment-request (instead of the objects for
 			voucher-request (CMS-signed JSON) and enrollment-request (PKCS#10). </t>
-			
-        <t> The registrar-agent sends the pledge-voucher-request to the 
+
+        <t> The registrar-agent sends the pledge-voucher-request to the
 		    registrar with an HTTPS POST to the endpoint
 			"/.well-known/brski/requestvoucher". </t>
-			
-		<t> The pledge-voucher-request Content-Type used in the 
+
+		<t> The pledge-voucher-request Content-Type used in the
 		    pledge-responder-mode is defined in
 		   <xref target="I-D.richardson-anima-jose-voucher" /> as: </t>
-		<t> application/voucher-jose+json (see <xref target="pvr" /> for the 
-		    content definition). </t> 
-			
-		<t> The registrar-agent SHOULD include the "Accept" header field received 
-		    during the communication with the pledge, indicating the pledge 
-			acceptable Content-Type for the voucher-response. The voucher-response 
-			Content-Type "application/voucher-jose+json" is defined in 
-			<xref target="I-D.richardson-anima-jose-voucher" />. </t> 
-		
-		<t> Upon reception of the pledge-voucher-request, the registrar SHALL 
-		    perform the verification of the voucher-request parameter as defined 
-			in section 5.3 of <xref target="RFC8995" />. 
+		<t> application/voucher-jose+json (see <xref target="pvr" /> for the
+		    content definition). </t>
+
+		<t> The registrar-agent SHOULD include the "Accept" header field received
+		    during the communication with the pledge, indicating the pledge
+			acceptable Content-Type for the voucher-response. The voucher-response
+			Content-Type "application/voucher-jose+json" is defined in
+			<xref target="I-D.richardson-anima-jose-voucher" />. </t>
+
+		<t> Upon reception of the pledge-voucher-request, the registrar SHALL
+		    perform the verification of the voucher-request parameter as defined
+			in section 5.3 of <xref target="RFC8995" />.
 			In addition, the registrar shall verify the following parameters from
-			the pledge-voucher-request: 
-		    <list style="symbols"> 
-				<t> agent-provided-proximity-registrar-cert: MUST contain the 
-				    own LDevID(Reg) EE certificate to ensure the registrar in 
+			the pledge-voucher-request:
+		    <list style="symbols">
+				<t> agent-provided-proximity-registrar-cert: MUST contain the
+				    own LDevID(Reg) EE certificate to ensure the registrar in
 					proximity is the target registrar for the request. </t>
-                <t> agent-signed-data: The registrar MUST verify that the data 
-				    has been signed with the LDevID(RegAgt) credential indicated 
-					in the "kid" JOSE header parameter. If the certificate is 
-					not contained in the agent-sign-cert component of the 
-					pledge-voucher-request, it must fetch the certificate from 
+                <t> agent-signed-data: The registrar MUST verify that the data
+				    has been signed with the LDevID(RegAgt) credential indicated
+					in the "kid" JOSE header parameter. If the certificate is
+					not contained in the agent-sign-cert component of the
+					pledge-voucher-request, it must fetch the certificate from
 					a repository. </t>
-				<t> agent-sign-cert: May contain the base64-encoded LDevID(RegAgt) 
-				    certificate. If contained the registrar MUST verify that the 
-					connected credential used to sign the data was valid at 
-					signature creation time and that the corresponding 
-					registrar-agent was authorized to be involved in the 
+				<t> agent-sign-cert: May contain the base64-encoded LDevID(RegAgt)
+				    certificate. If contained the registrar MUST verify that the
+					connected credential used to sign the data was valid at
+					signature creation time and that the corresponding
+					registrar-agent was authorized to be involved in the
 					bootstrapping.</t>
 			</list></t>
-	
+
 		<t> If validation fails the registrar SHOULD respond with the HTTP 404
-		    error code to the registrar-agent. If the pledge-voucher-request is in an 
+		    error code to the registrar-agent. If the pledge-voucher-request is in an
 			unknown format, then an HTTP 406 error code is more appropriate. </t>
-			
-        <t> If validation succeeds, the registrar will accept the pledge request 
-		    to join the domain as defined in section 5.3 of 
-			<xref target="RFC8995" />. The registrar 
-			then establishes a TLS connection with the MASA as described in section 
-			5.4 of <xref target="RFC8995" /> to 
+
+        <t> If validation succeeds, the registrar will accept the pledge request
+		    to join the domain as defined in section 5.3 of
+			<xref target="RFC8995" />. The registrar
+			then establishes a TLS connection with the MASA as described in section
+			5.4 of <xref target="RFC8995" /> to
 			obtain a voucher for the pledge. </t>
 
-		<t> The registrar SHALL construct the body of the registrar-voucher-request 
-		    object as defined in 
-			<xref target="RFC8995" />. 
-			The encoding SHALL be done as JOSE object as defined in 
-			<xref target="I-D.richardson-anima-jose-voucher" />. </t>		
-		
-		<t> The header of the registrar-voucher-request SHALL contain the following 
+		<t> The registrar SHALL construct the body of the registrar-voucher-request
+		    object as defined in
+			<xref target="RFC8995" />.
+			The encoding SHALL be done as JOSE object as defined in
+			<xref target="I-D.richardson-anima-jose-voucher" />. </t>
+
+		<t> The header of the registrar-voucher-request SHALL contain the following
 		    parameter as defined in <xref target="RFC7515" />:
 			<list style="symbols">
                 <t>alg: algorithm used for creating the object signature.</t>
-                <t>x5c: contains the base64-encoded registrar LDevID certificate. </t>			
+                <t>x5c: contains the base64-encoded registrar LDevID certificate. </t>
 			</list>	</t>
 
-		<t> The body of the registrar-voucher-request object MUST contain the 
-		    following parameter as part of the ietf-voucher-request:voucher as 
+		<t> The body of the registrar-voucher-request object MUST contain the
+		    following parameter as part of the ietf-voucher-request:voucher as
 			defined in <xref target="RFC8995" />:
 			<list style="symbols">
-                <t>created-on: contains the current date and time in 
-				    yang:date-and-time format for the registrar-voucher-request 
+                <t>created-on: contains the current date and time in
+				    yang:date-and-time format for the registrar-voucher-request
 					creation time.</t>
                 <t>nonce: copied form the pledge-voucher-request</t>
-				<t>serial-number: contains the base64-encoded product-serial-number. 
+				<t>serial-number: contains the base64-encoded product-serial-number.
 				    The registrar MUST verify that the product-serial-number
-					contained in the IDevID certificate of the pledge matches 
-					the serial-number field in the pledge-voucher-request. 
+					contained in the IDevID certificate of the pledge matches
+					the serial-number field in the pledge-voucher-request.
 					In addition, it MUST be equal to the serial-number field
 					contained in the agent-signed data of pledge-voucher-request. </t>
-				<t>assertion: contains the voucher assertion requested the pledge 
-				    (agent-proximity). The registrar provides this 
-				    information to assure successful verification of agent 
+				<t>assertion: contains the voucher assertion requested the pledge
+				    (agent-proximity). The registrar provides this
+				    information to assure successful verification of agent
 					proximity based on the agent-signed-data. </t>
 			</list>	</t>
-			
-		<t> The ietf-voucher-request:voucher can be optionally enhanced with the 
+
+		<t> The ietf-voucher-request:voucher can be optionally enhanced with the
             following additional parameter:
 			<list style="symbols">
-				<t>agent-sign-cert: Contain the base64-encoded LDevID(RegAgt) 
-				    EE certificate if MASA verification of agent-proximity is 
+				<t>agent-sign-cert: Contain the base64-encoded LDevID(RegAgt)
+				    EE certificate if MASA verification of agent-proximity is
 					required to provide the assertion "agent-proximity".</t>
 			</list>	</t>
-					
-			
-		<t>	The object is signed using the registrar LDevID(Reg) credential, 
+
+
+		<t>	The object is signed using the registrar LDevID(Reg) credential,
 		    which corresponds to the certificate signaled in the JOSE header. </t>
 
 <figure anchor="rvr" title="Example of registrar-voucher-request">
 <artwork name="" type="" align="left" alt=""><![CDATA[
 {
-   "alg": "ES256", 
-   "x5c": ["MIIB2jCC...dA=="] 
+   "alg": "ES256",
+   "x5c": ["MIIB2jCC...dA=="]
 }
 {
   "ietf-voucher-request:voucher": {
@@ -1832,76 +1832,76 @@ registrar-agent and infrastructure bootstrapping services">
    "nonce": "eDs++/FuDHGUnRxN3E14CQ==",
    "serial-number": "callee4711",
    "assertion": "agent-proximity",
-   "prior-signed-voucher-request": "base64encodedvalue==",  
-   "agent-sign-cert": "base64encodedvalue=="     
+   "prior-signed-voucher-request": "base64encodedvalue==",
+   "agent-sign-cert": "base64encodedvalue=="
   }
 }
 {
     SIGNATURE
 }
 ]]></artwork>
-</figure>		
+</figure>
 
-		<t> The registrar sends the registrar-voucher-request to the 
+		<t> The registrar sends the registrar-voucher-request to the
 		    MASA with an HTTPS POST at the endpoint
 			"/.well-known/brski/requestvoucher". </t>
-			
+
 		<t>	The registrar-voucher-request Content-Type is defined in
 		   <xref target="I-D.richardson-anima-jose-voucher" /> as: </t>
 		<t> application/voucher-jose+json</t>
-		
-		<t>	The registrar SHOULD include an "Accept" header field indicating the 
-		    acceptable media type for the voucher-response. The media type 
-			"application/voucher-jose+json" is defined in 
-			<xref target="I-D.richardson-anima-jose-voucher" />. </t> 
 
-		<t>	Once the MASA receives the registrar-voucher-request it SHALL 
-		    perform the verification of the contained components as described in 	
+		<t>	The registrar SHOULD include an "Accept" header field indicating the
+		    acceptable media type for the voucher-response. The media type
+			"application/voucher-jose+json" is defined in
+			<xref target="I-D.richardson-anima-jose-voucher" />. </t>
+
+		<t>	Once the MASA receives the registrar-voucher-request it SHALL
+		    perform the verification of the contained components as described in
 			section 5.5 in <xref target="RFC8995" />.
-			In addition, the following additional processing SHALL be done for 
-			components contained in the prior-signed-voucher-request: 
-		    <list style="symbols"> 
-				<t> agent-provided-proximity-registrar-cert: The MASA MAY verify 
-				    that this field contains the LDevID(Reg) certificate. If so, 
-					it MUST be consistent with the certificate used to sign the 
+			In addition, the following additional processing SHALL be done for
+			components contained in the prior-signed-voucher-request:
+		    <list style="symbols">
+				<t> agent-provided-proximity-registrar-cert: The MASA MAY verify
+				    that this field contains the LDevID(Reg) certificate. If so,
+					it MUST be consistent with the certificate used to sign the
 					registrar-voucher-request. </t>
-                <t> agent-signed-data: The MASA MAY verify this field to be able 
-				    to provide an assertion "agent-proximity". If so, the 
-					agent-signed-data MUST contain the product-serial-number of 
-					the pledge contained in the serial-number component of the 
-					prior-signed-voucher and also in serial-number component of 
-					the registrar-voucher-request. The LDevID(RegAgt) used to 
-					generate provide the signature is identified by the "kid" 
-					parameter of the JOSE header (agent-signed-data). If the 
-					assertion "agent-proximity" is requested, the 
-					registrar-voucher-request MUST contain the corresponding 
-					LDevID(RegAgt) EE certificate in the agent-sign-cert, which 
-					can be verified by the MASA as issued by the same domain CA 
-					as the LDevID(Reg) EE certificate. If the agent-sign-cert is 
-					not provided, the MASA MAY provide a lower level assertion 
+                <t> agent-signed-data: The MASA MAY verify this field to be able
+				    to provide an assertion "agent-proximity". If so, the
+					agent-signed-data MUST contain the product-serial-number of
+					the pledge contained in the serial-number component of the
+					prior-signed-voucher and also in serial-number component of
+					the registrar-voucher-request. The LDevID(RegAgt) used to
+					generate provide the signature is identified by the "kid"
+					parameter of the JOSE header (agent-signed-data). If the
+					assertion "agent-proximity" is requested, the
+					registrar-voucher-request MUST contain the corresponding
+					LDevID(RegAgt) EE certificate in the agent-sign-cert, which
+					can be verified by the MASA as issued by the same domain CA
+					as the LDevID(Reg) EE certificate. If the agent-sign-cert is
+					not provided, the MASA MAY provide a lower level assertion
 					"logged" or "verified"</t>
 			</list></t>
-			
-	
-		<t> If validation fails, the MASA SHOULD respond with an HTTP 
-		    error code to the registrar. The error codes are kept as defined in 
-			section 5.6 of <xref target="RFC8995" />. 
-			and comprise the response codes 403, 404, 406, and 415. </t>			
 
-        <t> The voucher response format is as indicated in the submitted 
-		    Accept header fields or based on the MASA's prior understanding of 
-			proper format for this pledge. Specifically for the 
-			pledge-responder-mode the "application/voucher-jose+json" as defined 
+
+		<t> If validation fails, the MASA SHOULD respond with an HTTP
+		    error code to the registrar. The error codes are kept as defined in
+			section 5.6 of <xref target="RFC8995" />.
+			and comprise the response codes 403, 404, 406, and 415. </t>
+
+        <t> The voucher response format is as indicated in the submitted
+		    Accept header fields or based on the MASA's prior understanding of
+			proper format for this pledge. Specifically for the
+			pledge-responder-mode the "application/voucher-jose+json" as defined
 			in <xref target="I-D.richardson-anima-jose-voucher" /> is applied.
-			The syntactic details of vouchers are described in detail in 
-			<xref target="RFC8366" />. <xref target="MASA-vr" /> shows an 
+			The syntactic details of vouchers are described in detail in
+			<xref target="RFC8366" />. <xref target="MASA-vr" /> shows an
 			example of the contents of a voucher. </t>
 
 <figure anchor="MASA-vr" title="Example of MASA issued voucher">
 <artwork name="" type="" align="left" alt=""><![CDATA[
 {
-    "alg": "ES256", 
-    "x5c": ["MIIBkzCCAT...dA=="] 
+    "alg": "ES256",
+    "x5c": ["MIIBkzCCAT...dA=="]
 }
 {
   "ietf-voucher:voucher": {
@@ -1909,7 +1909,7 @@ registrar-agent and infrastructure bootstrapping services">
     "serial-number": "callee4711",
     "nonce": "eDs++/FuDHGUnRxN3E14CQ==",
     "created-on": "2021-04-17T00:00:02.000Z",
-    "pinned-domain-cert": "MIIBpDCCA...w=="    
+    "pinned-domain-cert": "MIIBpDCCA...w=="
   }
 }
 {
@@ -1918,148 +1918,148 @@ registrar-agent and infrastructure bootstrapping services">
 
 ]]></artwork>
 </figure>
-	
-		<t> The MASA sends the voucher in the indicated form to the 
-		    registrar. After receiving the voucher the registrar may evaluate 
-			the voucher for transparency and logging purposes as outlined in 
+
+		<t> The MASA sends the voucher in the indicated form to the
+		    registrar. After receiving the voucher the registrar may evaluate
+			the voucher for transparency and logging purposes as outlined in
 			section 5.6 of <xref target="RFC8995" />.
-			The registrar forwards the voucher without changes to the 
+			The registrar forwards the voucher without changes to the
 			registrar-agent. </t>
-			
-		<t> After receiving the voucher, the registrar-agent sends the 
-		    pledge's enrollment-request to the registrar. Deviating from BRSKI 
-			the enrollment-request is not a raw PKCS#10 request. As the 
-			registrar-agent is involved in the exchange, the PKCS#10 is contained 
-			in the JOSE object. The signature is created using the pledge's 
-			IDevID to provide proof-of-identity as outlined in 
+
+		<t> After receiving the voucher, the registrar-agent sends the
+		    pledge's enrollment-request to the registrar. Deviating from BRSKI
+			the enrollment-request is not a raw PKCS#10 request. As the
+			registrar-agent is involved in the exchange, the PKCS#10 is contained
+			in the JOSE object. The signature is created using the pledge's
+			IDevID to provide proof-of-identity as outlined in
 			<xref target="per" />. </t>
-			
-		<t> When using EST, the registrar-agent sends the enrollment request 
+
+		<t> When using EST, the registrar-agent sends the enrollment request
 		    to the registrar with an HTTPS POST at the endpoint
 			"/.well-known/est/simpleenroll". </t>
-			
+
 		<t>	The enrollment-request Content-Type is: </t>
 		<t> application/jose </t>
-				
-		<t> If validation of the wrapping signature fails, the registrar SHOULD 
-		     respond with the HTTP 404 error code.  If the voucher-request is 
-			 in an unknown format, then an HTTP 406 error code is more appropriate.  
-			 A situation that could be resolved with administrative action (such 
-			 as adding a vendor/manufacturer IDevID CA as trusted party) MAY be 
+
+		<t> If validation of the wrapping signature fails, the registrar SHOULD
+		     respond with the HTTP 404 error code.  If the voucher-request is
+			 in an unknown format, then an HTTP 406 error code is more appropriate.
+			 A situation that could be resolved with administrative action (such
+			 as adding a vendor/manufacturer IDevID CA as trusted party) MAY be
 			 responded with an 403 HTTP error code. </t>
 
-		<t>	This results in a deviation from the content types used in 
-		    <xref target="RFC7030" /> and results in additional processing at 
-			the domain registrar as EST server as following. Note that the 
-			registrar is already aware that the bootstrapping is performed in 
-			a pledge-responder-mode due to the use of the LDevID(RegAgt) 
-			certificate in the TLS establishment and the provided 
-			pledge-voucher-request in JOSE object. 			
-		    <list style="symbols"> 
+		<t>	This results in a deviation from the content types used in
+		    <xref target="RFC7030" /> and results in additional processing at
+			the domain registrar as EST server as following. Note that the
+			registrar is already aware that the bootstrapping is performed in
+			a pledge-responder-mode due to the use of the LDevID(RegAgt)
+			certificate in the TLS establishment and the provided
+			pledge-voucher-request in JOSE object.
+		    <list style="symbols">
         		<t> If registrar receives the enrollment-request with the Content
-				    Type application/jose, it MUST verify the signature using the 
+				    Type application/jose, it MUST verify the signature using the
 					certificate indicated in the JOSE header. </t>
-				<t> The domain registrar verifies that the serial-number contained 
-				    in the pledge's IDevID certificate contained in the JOSE header 
-					as being accepted to join the domain, based on the verification 
+				<t> The domain registrar verifies that the serial-number contained
+				    in the pledge's IDevID certificate contained in the JOSE header
+					as being accepted to join the domain, based on the verification
 					of the pledge-voucher-request.</t>
                 <t> If both succeed, the registrar utilizes the PKCS#10 request
-				    contained in the JOSE body as "P10" parameter of 
-					"ietf-sztp-csr:csr" for further processing of the enrollment 
+				    contained in the JOSE body as "P10" parameter of
+					"ietf-sztp-csr:csr" for further processing of the enrollment
 					request with the domain CA.</t>
-		    </list></t>				
+		    </list></t>
 
 		<t> [RFC Editor: please delete] /* </t>
 		<t> Open Issues:
-		    <list style="symbols"> 
-				<t> The domain registrar may either enhance the PKCS#10 request 
-					or generate a structure containing the attributes to be 
-					included by the CA and sends both (the original PKCS#10 
-					request and the enhancements) to the domain CA. As enhancing 
-					the PKCS#10 request destroys the initial proof of possession 
-					of the corresponding private key, the CA would need to 
+		    <list style="symbols">
+				<t> The domain registrar may either enhance the PKCS#10 request
+					or generate a structure containing the attributes to be
+					included by the CA and sends both (the original PKCS#10
+					request and the enhancements) to the domain CA. As enhancing
+					the PKCS#10 request destroys the initial proof of possession
+					of the corresponding private key, the CA would need to
 					accept RA-verified requests.</t>
-		   </list></t>	
-	
-        <t> A successful interaction with the domain CA will result in the pledge 
-		    LDevID EE certificate, which is then forwarded by the registrar to the 
+		   </list></t>
+
+        <t> A successful interaction with the domain CA will result in the pledge
+		    LDevID EE certificate, which is then forwarded by the registrar to the
 			registrar-agent using the content type "application/pkcs7-mime". </t>
-			
-		<t>	The registrar-agent has now finished the exchanges with the 
-			domain registrar. Now the registrar-agent can supply the voucher-response 
-			(from MASA via Registrar) and the enrollment-response (LDevID EE 
-			certificate) to the pledge. It can close the TLS connection to the 
-			domain registrar and provide the objects to the pledge(s). The content 
-			of the response objects is defined through the voucher 
-			<xref target="RFC8366" /> and the certificate <xref target="RFC5280" />. </t>			
+
+		<t>	The registrar-agent has now finished the exchanges with the
+			domain registrar. Now the registrar-agent can supply the voucher-response
+			(from MASA via Registrar) and the enrollment-response (LDevID EE
+			certificate) to the pledge. It can close the TLS connection to the
+			domain registrar and provide the objects to the pledge(s). The content
+			of the response objects is defined through the voucher
+			<xref target="RFC8366" /> and the certificate <xref target="RFC5280" />. </t>
 
 		</section>
 
 
  	    <section anchor="exchanges_uc2_3" title="Response object supply (registrar-agent - pledge)">
 
-	    <t> The following description assumes that the registrar-agent has 
-		    obtained the response objects from the domain registrar. It will 
-			re-start the interaction with the pledge. To contact the pledge, 
-			it may either discover the pledge as described in 
-			<xref target="discovery_uc2_ppa" /> or use stored information 
+	    <t> The following description assumes that the registrar-agent has
+		    obtained the response objects from the domain registrar. It will
+			re-start the interaction with the pledge. To contact the pledge,
+			it may either discover the pledge as described in
+			<xref target="discovery_uc2_ppa" /> or use stored information
 			from the first contact with the pledge.</t>
-				
+
 		<t> Preconditions in addition to <xref target="exchanges_uc2_2" />: </t>
-		<t> <list style="symbols"> 
+		<t> <list style="symbols">
 				<t> Registrar-agent: possesses voucher and LDevID certificate. </t>
 			</list> </t>
 
-<figure anchor="exchangesfig_uc2_3" title="Response and status handling between pledge and 
+<figure anchor="exchangesfig_uc2_3" title="Response and status handling between pledge and
 registrar-agent">
 <artwork name="" type="" align="left" alt=""><![CDATA[
-+--------+                        +-----------+   
-| Pledge |                        | Registrar |   
-|        |                        | Agent     |   
-|        |                        | (RegAgt)  |   
-+--------+                        +-----------+        
-    |                                   | 
-    |<------- supply voucher -----------|       
-    |                                   |                
-    |--------- voucher-status --------->| - store   
-    |                                   |   pledge voucher-status   
-    |<--- supply enrollment response ---|       
-    |                                   | 
-    |--------- enroll-status ---------->| - store       
-    |                                   |   pledge enroll-status    
++--------+                        +-----------+
+| Pledge |                        | Registrar |
+|        |                        | Agent     |
+|        |                        | (RegAgt)  |
++--------+                        +-----------+
+    |                                   |
+    |<------- supply voucher -----------|
+    |                                   |
+    |--------- voucher-status --------->| - store
+    |                                   |   pledge voucher-status
+    |<--- supply enrollment response ---|
+    |                                   |
+    |--------- enroll-status ---------->| - store
+    |                                   |   pledge enroll-status
 ]]></artwork>
 </figure>
-       
-		<t> The registrar-agent provides the information via two distinct 
+
+		<t> The registrar-agent provides the information via two distinct
 		    endpoints to the pledge as following.</t>
-			
-		<t>	The voucher response is provided with a HTTP POST using the 
+
+		<t>	The voucher response is provided with a HTTP POST using the
 		    operation path value of "/.well-known/brski/pledge-voucher".  </t>
-			
-        <t> The registrar-agent voucher-response Content-Type header is 
-		    "application/voucher-jose+json and contains the voucher as provided 
+
+        <t> The registrar-agent voucher-response Content-Type header is
+		    "application/voucher-jose+json and contains the voucher as provided
 			by the MASA. An example if given in <xref target="MASA-vr" />. </t>
-			
-		<t> The pledge verifies the voucher as described in section 5.6.1 in 
+
+		<t> The pledge verifies the voucher as described in section 5.6.1 in
 		    <xref target="RFC8995" />. </t>
-		
-		<t> After successful verification the pledge MUST reply with a status 
-		    telemetry message as defined in section 5.7 of 
-			<xref target="RFC8995" />. As for the 
-			other objects, the defined object is provided with an additional 
+
+		<t> After successful verification the pledge MUST reply with a status
+		    telemetry message as defined in section 5.7 of
+			<xref target="RFC8995" />. As for the
+			other objects, the defined object is provided with an additional
 			signature using JOSE. The pledge generates the voucher-status-object
 			and provides it in the response message to the registrar-agent. </t>
-			
-		<t>	The response has the Content-Type "application/jose", signed using 
-			the IDevID of the pledge as shown in <xref target="vstat" />. 
-			As the reason field is optional (see <xref target="RFC8995" />), 
+
+		<t>	The response has the Content-Type "application/jose", signed using
+			the IDevID of the pledge as shown in <xref target="vstat" />.
+			As the reason field is optional (see <xref target="RFC8995" />),
 			it MAY be omitted in case of success. </t>
 
 <figure anchor="vstat" title="Example of pledge voucher-status telemetry">
 <artwork name="" type="" align="left" alt=""><![CDATA[
 {
-    "alg": "ES256", 
-    "x5c": ["MIIB2jCC...dA=="]    
+    "alg": "ES256",
+    "x5c": ["MIIB2jCC...dA=="]
 {
     "version": 1,
     "status":true,
@@ -2072,41 +2072,41 @@ registrar-agent">
 ]]></artwork>
 </figure>
 
-		<t>	The enrollment response is provided with a HTTP POST using the 
+		<t>	The enrollment response is provided with a HTTP POST using the
 		    operation path value of "/.well-known/brski/pledge-enrollment". </t>
-			
-        <t> The registrar-agent enroll-response Content-Type header when using 
-		    EST <xref target="RFC7030" /> as enrollment protocol, from the 
+
+        <t> The registrar-agent enroll-response Content-Type header when using
+		    EST <xref target="RFC7030" /> as enrollment protocol, from the
 			registrar-agent to the infrastructure is:</t>
-		
-        <t> application/pkcs7-mime: note that it only contains the LDevID 
+
+        <t> application/pkcs7-mime: note that it only contains the LDevID
 		    certificate for the pledge, not the certificate chain.</t>
-		
+
 		<t> [RFC Editor: please delete] /* </t>
-		<t> Open Issue: the enrollment response object may also be an 
-		    application/jose object with a signature of the domain registrar. 
-			This may be used either to transport additional data which is bound 
-			to the LDevID or it may be considered for enrollment status to 
-			ensure that in an error case the registrar providing the certificate 
+		<t> Open Issue: the enrollment response object may also be an
+		    application/jose object with a signature of the domain registrar.
+			This may be used either to transport additional data which is bound
+			to the LDevID or it may be considered for enrollment status to
+			ensure that in an error case the registrar providing the certificate
 			can be identified. */</t>
-	    
-		<t> After successful verification the pledge MUST reply with a status 
-		    telemetry message as defined in section 5.9.4 of 
-			<xref target="RFC8995" />. As for the 
-			other objects, the defined object is provided with an additional 
-			signature using the JOSE. The pledge generates the enrollment status 
+
+		<t> After successful verification the pledge MUST reply with a status
+		    telemetry message as defined in section 5.9.4 of
+			<xref target="RFC8995" />. As for the
+			other objects, the defined object is provided with an additional
+			signature using the JOSE. The pledge generates the enrollment status
 			and provides it in the response message to the registrar-agent. </t>
-			
-		<t>	The response has the Content-Type "application/jose", signed using 
-			the LDevID of the pledge as shown in <xref target="estat" />. 
-			As the reason field is optional, it MAY be omitted in case of 
+
+		<t>	The response has the Content-Type "application/jose", signed using
+			the LDevID of the pledge as shown in <xref target="estat" />.
+			As the reason field is optional, it MAY be omitted in case of
 			success. </t>
 
 <figure anchor="estat" title="Example of pledge enroll-status telemetry">
 <artwork name="" type="" align="left" alt=""><![CDATA[
 {
-  "alg": "ES256", 
-  "x5c": ["MIIB56uz...dA=="]   
+  "alg": "ES256",
+  "x5c": ["MIIB56uz...dA=="]
 {
   "version": 1,
   "status":true,
@@ -2118,25 +2118,25 @@ registrar-agent">
 }
 ]]></artwork>
 </figure>
-			
-		<t> Once the registrar-agent has collected the information, it can 
-		    connect to the registrar agent to provide the status responses to 
-			the registrar. </t> 
+
+		<t> Once the registrar-agent has collected the information, it can
+		    connect to the registrar agent to provide the status responses to
+			the registrar. </t>
 		</section>
 
  	    <section anchor="exchanges_uc2_4" title="Telemetry status handling (registrar-agent - domain registrar)">
-	    <t> The following description assumes that the registrar-agent has 
-		    collected the status objects from the pledge. It will provide the 
-			status objects to the registrar for further processing and audit log 
+	    <t> The following description assumes that the registrar-agent has
+		    collected the status objects from the pledge. It will provide the
+			status objects to the registrar for further processing and audit log
 			information of voucher-status for MASA. </t>
-				
+
 		<t> Preconditions in addition to <xref target="exchanges_uc2_2" />: </t>
-		<t> <list style="symbols"> 
-				<t> Registrar-agent: possesses voucher-status and enroll-status 
+		<t> <list style="symbols">
+				<t> Registrar-agent: possesses voucher-status and enroll-status
 				    objects from pledge. </t>
 			</list> </t>
-			
-	
+
+
 <figure anchor="exchangesfig_uc2_4" title="Bootstrapping status handling">
 <artwork name="" type="" align="left" alt=""><![CDATA[
 +-----------+    +-----------+   +--------+   +---------+
@@ -2158,95 +2158,95 @@ registrar-agent">
 ]]></artwork>
 </figure>
 
-        <t> The registrar-agent MUST provide the collected pledge voucher-status 
-		    to the registrar. This status indicates the pledge could process the 
+        <t> The registrar-agent MUST provide the collected pledge voucher-status
+		    to the registrar. This status indicates the pledge could process the
 			voucher successfully or not.</t>
-			
-		<t> If the TLS connection to the registrar was closed, the registrar-agent 
-		    establishes a TLS connection with the registrar as stated in 
-			<xref target="exchanges_uc2_2" />. </t>			
-			
+
+		<t> If the TLS connection to the registrar was closed, the registrar-agent
+		    establishes a TLS connection with the registrar as stated in
+			<xref target="exchanges_uc2_2" />. </t>
+
 		<t> The registrar-agent sends the pledge voucher-status object
-		    without modification to the registrar with an HTTPS POST using the 
-			operation path value of "/.well-known/brski/voucher_status". The 
-			Content-Type header is kept as "application/jose" as described in 
-			<xref target="exchangesfig_uc2_3" /> and depicted in the example in 
+		    without modification to the registrar with an HTTPS POST using the
+			operation path value of "/.well-known/brski/voucher_status". The
+			Content-Type header is kept as "application/jose" as described in
+			<xref target="exchangesfig_uc2_3" /> and depicted in the example in
 			<xref target="vstat" />.</t>
 
-		<t> The registrar SHALL verify the signature of the pledge voucher-status 
+		<t> The registrar SHALL verify the signature of the pledge voucher-status
 		    and validate that it belongs to an accepted device in his domain
-            based on the contained "serial-number" in the IDevID certificate 
+            based on the contained "serial-number" in the IDevID certificate
 			referenced in the header of the voucher-status object. </t>
-		
-		<t> According to <xref target="RFC8995" /> 
-		    section 5.7, the registrar SHOULD respond with an HTTP 200 but MAY 
-			simply fail with an HTTP 404 error.  The registrar-agent may use the 
-			response to signal success / failure to the service technician 
-			operating the registrar agent. Within the server logs the server 
+
+		<t> According to <xref target="RFC8995" />
+		    section 5.7, the registrar SHOULD respond with an HTTP 200 but MAY
+			simply fail with an HTTP 404 error.  The registrar-agent may use the
+			response to signal success / failure to the service technician
+			operating the registrar agent. Within the server logs the server
 			SHOULD capture this telemetry information. </t>
-			
-        <t> The registrar SHOULD proceed with the collecting and logging the 
-		    status information by requesting the MASA audit-log from the MASA 
-			service as described in section 5.8 of 
+
+        <t> The registrar SHOULD proceed with the collecting and logging the
+		    status information by requesting the MASA audit-log from the MASA
+			service as described in section 5.8 of
 			<xref target="RFC8995" />. </t>
 
-		
-		<t> The registrar-agent MUST provide the enroll-status object to the 
-		    registrar. The status indicates the pledge could process the 
+
+		<t> The registrar-agent MUST provide the enroll-status object to the
+		    registrar. The status indicates the pledge could process the
 			enroll-response object and holds the corresponding private key. </t>
 
 		<t> The registrar-agent sends the pledge enroll-status object
-		    without modification to the registrar with an HTTPS POST using the 
-			operation path value of "/.well-known/brski/enrollstatus". The 
-			Content-Type header is kept as "application/jose" as described in 
-			<xref target="exchangesfig_uc2_3" /> and depicted in the example in 
+		    without modification to the registrar with an HTTPS POST using the
+			operation path value of "/.well-known/brski/enrollstatus". The
+			Content-Type header is kept as "application/jose" as described in
+			<xref target="exchangesfig_uc2_3" /> and depicted in the example in
 			<xref target="estat" />.</t>
 
-		<t> The registrar SHALL verify the signature of the pledge enroll-status 
+		<t> The registrar SHALL verify the signature of the pledge enroll-status
 		    object and validate that it belongs to an accepted device in his domain
-            based on the contained product-serial-number in the LDevID EE certificate 
-			referenced in the header of the enroll-status object. Note that 
-			the verification of a signature of the object is a deviation form 
-			the described handling in section 5.9.4 of 
+            based on the contained product-serial-number in the LDevID EE certificate
+			referenced in the header of the enroll-status object. Note that
+			the verification of a signature of the object is a deviation form
+			the described handling in section 5.9.4 of
 			<xref target="RFC8995" />. </t>
-			
-		<t> According to <xref target="RFC8995" /> 
-		    section 5.9.4, the registrar SHOULD respond with an HTTP 200 but MAY 
-			simply fail with an HTTP 404 error.  The registrar-agent may use the 
-			response to signal success / failure to the service technician 
-			operating the registrar agent. Within the server log the registrar 
+
+		<t> According to <xref target="RFC8995" />
+		    section 5.9.4, the registrar SHOULD respond with an HTTP 200 but MAY
+			simply fail with an HTTP 404 error.  The registrar-agent may use the
+			response to signal success / failure to the service technician
+			operating the registrar agent. Within the server log the registrar
 			SHOULD capture this telemetry information. </t>
-	
+
 		</section>
 	  </section>
 	</section>
-	  
+
       <section anchor="discovery_eo" title="Domain registrar support of different enrollment options">
-        <t> Well-known URIs for different endpoints on the domain registrar are 
-		    already defined as part of the base BRSKI specification. In 
-			addition, alternative enrollment endpoints may be supported at the 
-			domain registrar. The pledge / registrar-agent will recognize if its 
-			supported enrollment option is supported by the domain registrar 
+        <t> Well-known URIs for different endpoints on the domain registrar are
+		    already defined as part of the base BRSKI specification. In
+			addition, alternative enrollment endpoints may be supported at the
+			domain registrar. The pledge / registrar-agent will recognize if its
+			supported enrollment option is supported by the domain registrar
 			by sending a request to its preferred enrollment endpoint.</t>
-			  			  
-        <t> The following provides an illustrative example for a domain 
-		    registrar supporting different options for EST as well as 
-		    CMP to be used in BRSKI-AE. The listing contains the supported 
-			endpoints for the bootstrapping, to which the pledge may connect. This 
-			includes the voucher handling as well as the enrollment endpoints. 
-			The CMP related enrollment endpoints are defined as well-known URI 
+
+        <t> The following provides an illustrative example for a domain
+		    registrar supporting different options for EST as well as
+		    CMP to be used in BRSKI-AE. The listing contains the supported
+			endpoints for the bootstrapping, to which the pledge may connect. This
+			includes the voucher handling as well as the enrollment endpoints.
+			The CMP related enrollment endpoints are defined as well-known URI
 			in CMP Updates <xref target="I-D.ietf-lamps-cmp-updates" />.</t>
-		  
+
         <figure>
 <artwork name="" type="" align="left" alt=""><![CDATA[
-  </brski/voucherrequest>,ct=voucher-cms+json  
-  </brski/voucher_status>,ct=json  
-  </brski/enrollstatus>,ct=json  
+  </brski/voucherrequest>,ct=voucher-cms+json
+  </brski/voucher_status>,ct=json
+  </brski/enrollstatus>,ct=json
   </est/cacerts>;ct=pkcs7-mime
   </est/simpleenroll>;ct=pkcs7-mime
   </est/simplereenroll>;ct=pkcs7-mime
   </est/fullcmc>;ct=pkcs7-mime
-  </est/serverkeygen>;ct= pkcs7-mime 
+  </est/serverkeygen>;ct= pkcs7-mime
   </est/csrattrs>;ct=pkcs7-mime
   </cmp/initialization>;ct=pkixcmp
   </cmp/certification>;ct=pkixcmp
@@ -2254,16 +2254,16 @@ registrar-agent">
   </cmp/p10>;ct=pkixcmp
   </cmp/getCAcert>;ct=pkixcmp
   </cmp/getCSRparam>;ct=pkixcmp
-  
+
 ]]></artwork>
 		</figure>
-		 
+
 		<t> [RFC Editor: please delete] /* </t>
 		<t> Open Issues:
 		 <list style="symbols">
- 	       <t> In addition to the current content types, we may specify that 
+ 	       <t> In addition to the current content types, we may specify that
 			   the response provide information about different content types
-               as multiple values. This would allow to further adopt the 
+               as multiple values. This would allow to further adopt the
 			   encoding of the objects exchanges (ASN.1, JSON, CBOR, ...).
 			   -> dependent on the utilized protocol. </t>
          </list>
@@ -2271,67 +2271,67 @@ registrar-agent">
         </t>
       </section>
     </section>
-       
+
 	<section anchor="exist_prot" title="Example for signature-wrapping using existing enrollment protocols">
-	  <t> This section map the requirements to support proof of possession and 
+	  <t> This section map the requirements to support proof of possession and
 	      proof of identity to selected existing enrollment protocols.
-	      Note that that the work in the ACE WG described in 
-	      <xref target="I-D.selander-ace-coap-est-oscore" /> may be considered 
-	      here as well, as it also addresses the encapsulation of EST in a way to 
-	      make it independent from the underlying TLS using OSCORE resulting in 
-	      an authenticated self-contained object. </t>		
+	      Note that that the work in the ACE WG described in
+	      <xref target="I-D.selander-ace-coap-est-oscore" /> may be considered
+	      here as well, as it also addresses the encapsulation of EST in a way to
+	      make it independent from the underlying TLS using OSCORE resulting in
+	      an authenticated self-contained object. </t>
 
 	  <section title="EST Handling">
-	    <t> When using EST <xref target="RFC7030" />, the following constraints 
+	    <t> When using EST <xref target="RFC7030" />, the following constraints
 		    should be considered:</t>
 	    <t>
 	     <list style="symbols">
-	       <t> Proof of possession is provided by using the specified PKCS#10 
+	       <t> Proof of possession is provided by using the specified PKCS#10
 		       structure in the request. </t>
-		   <t> Proof of identity is achieved by signing the certification 
-		       request object, which is only supported when Full PKI Request 
-			   (the /fullcmc endpoint) is used. This contains sufficient 
-			   information for the RA to make an authorization decision on the 
+		   <t> Proof of identity is achieved by signing the certification
+		       request object, which is only supported when Full PKI Request
+			   (the /fullcmc endpoint) is used. This contains sufficient
+			   information for the RA to make an authorization decision on the
 			   received certification request.
-			   Note: EST references CMC <xref target="RFC5272" /> for the 
-			   definition of the Full PKI Request. For proof of identity, the 
-			   signature of the SignedData of the Full PKI Request would be 
+			   Note: EST references CMC <xref target="RFC5272" /> for the
+			   definition of the Full PKI Request. For proof of identity, the
+			   signature of the SignedData of the Full PKI Request would be
 			   calculated using the IDevID credential of the pledge. </t>
-		   <t> [RFC Editor: please delete] /* TBD: in this case the binding to 
+		   <t> [RFC Editor: please delete] /* TBD: in this case the binding to
 		       the underlying TLS connection is not be necessary. */</t>
-	       <t> When the RA is not available, as per <xref target="RFC7030" /> 
-		       Section 4.2.3, a 202 return code should be returned by the 
-			   Registrar. The pledge in this case would retry a simpleenroll 
-			   with a PKCS#10 request. Note that if the TLS connection is teared 
-			   down for the waiting time, the PKCS#10 request would need to be 
-			   rebuilt if it contains the unique identifier (tls_unique) from 
+	       <t> When the RA is not available, as per <xref target="RFC7030" />
+		       Section 4.2.3, a 202 return code should be returned by the
+			   Registrar. The pledge in this case would retry a simpleenroll
+			   with a PKCS#10 request. Note that if the TLS connection is teared
+			   down for the waiting time, the PKCS#10 request would need to be
+			   rebuilt if it contains the unique identifier (tls_unique) from
 			   the underlying TLS connection for the binding. </t>
-		   <t> [RFC Editor: please delete] /* TBD: clarification of retry for 
+		   <t> [RFC Editor: please delete] /* TBD: clarification of retry for
 		       fullcmc is necessary as not specified in the context of EST */ </t>
 	     </list>
 	    </t>
        </section>
-	   
+
 	   <section title="CMP Handling">
-	    <t> Instead of using CMP <xref target="RFC4210" />, this specification 
-		    refers to the lightweight CMP profile 
-			<xref target="I-D.ietf-lamps-lightweight-cmp-profile" />, as it 
+	    <t> Instead of using CMP <xref target="RFC4210" />, this specification
+		    refers to the lightweight CMP profile
+			<xref target="I-D.ietf-lamps-lightweight-cmp-profile" />, as it
 			restricts the full featured CMP to the functionality needed here.
 			For this, the following constrains should be observed: </t>
 	    <t>
 	     <list style="symbols">
-	       <t> For proof of possession, the defined approach in Lightweight CMP 
-		       Profile section 4.1.1 (based on CRMF) and 4.1.5 (based on PCKS#10) 
+	       <t> For proof of possession, the defined approach in Lightweight CMP
+		       Profile section 4.1.1 (based on CRMF) and 4.1.5 (based on PCKS#10)
 			   should be supported. </t>
-	       <t> Proof of identity can be provided by using the signatures to 
-		       protect the certificate request message as outlined in section 
+	       <t> Proof of identity can be provided by using the signatures to
+		       protect the certificate request message as outlined in section
 			   3.2. of <xref target="I-D.ietf-lamps-lightweight-cmp-profile" />.</t>
-	       <t> When the RA/CA is not available, a waiting indication should be 
-		       returned in the PKIStatus by the Registrar. The pledge in this 
-			   case would retry using the PollReqContent with a request 
-			   identifier certReqId provided in the initial CertRequest message 
-			   as specified in section 5.2.4 of 
-			   <xref target="I-D.ietf-lamps-lightweight-cmp-profile" /> 
+	       <t> When the RA/CA is not available, a waiting indication should be
+		       returned in the PKIStatus by the Registrar. The pledge in this
+			   case would retry using the PollReqContent with a request
+			   identifier certReqId provided in the initial CertRequest message
+			   as specified in section 5.2.4 of
+			   <xref target="I-D.ietf-lamps-lightweight-cmp-profile" />
 			   with delayed enrollment. </t>
 	     </list>
 	    </t>
@@ -2341,10 +2341,10 @@ registrar-agent">
 
     <section title="IANA Considerations">
       <t>This document requires the following IANA actions:</t>
-	  
+
 	  <t> IANA is requested to enhance the Registry entitled: "BRSKI well-
 		  known URIs" with the following: </t>
-		  
+
       <figure>
 <artwork name="" type="" align="left" alt=""><![CDATA[
  URI                       document  description
@@ -2355,80 +2355,80 @@ registrar-agent">
  pledge-CACerts            [THISRFC] supply CA certs to pledge
 ]]></artwork>
 	  </figure>
-	  
-      <t> [RFC Editor: please delete] /* 
-	    to be done: IANA consideration to be included for the defined namespaces 
+
+      <t> [RFC Editor: please delete] /*
+	    to be done: IANA consideration to be included for the defined namespaces
 	    in <xref target="addressing" /> and <xref target="discovery_eo" /> .
 		*/
       </t>
     </section>
 
     <section title="Privacy Considerations">
-	  <t> The credential used by the registrar-agent to sign the data for the 
-	      pledge in case of the pledge-initiator-mode should not 
-		  contain personal information. Therefore, it is recommended to use an 
-		  LDevID certificate associated with the device instead of a potential 
-		  service technician operating the device, to avoid revealing this 
+	  <t> The credential used by the registrar-agent to sign the data for the
+	      pledge in case of the pledge-initiator-mode should not
+		  contain personal information. Therefore, it is recommended to use an
+		  LDevID certificate associated with the device instead of a potential
+		  service technician operating the device, to avoid revealing this
 		  information to the MASA. </t>
 
     </section>
 
     <section title="Security Considerations">
 	  <section title="Exhaustion attack on pledge">
-	  <t> Exhaustion attack on pledge based on DoS attack (connection 
+	  <t> Exhaustion attack on pledge based on DoS attack (connection
 	      establishment, etc.) </t>
 	  </section>
-		  
+
 	  <section title="Misuse of acquired voucher and enrollment responses">
-	  <t> Registrar-agent that uses acquired voucher and enrollment response for 
-	      domain 1 in domain 2: can be detected in Voucher Request processing 
-		  on domain registrar side. Requires domain registrar to verify the 
-		  proximity-registrar-cert leaf in the pledge-voucher-request against 
-		  his own as well as the association of the pledge to his domain based 
+	  <t> Registrar-agent that uses acquired voucher and enrollment response for
+	      domain 1 in domain 2: can be detected in Voucher Request processing
+		  on domain registrar side. Requires domain registrar to verify the
+		  proximity-registrar-cert leaf in the pledge-voucher-request against
+		  his own as well as the association of the pledge to his domain based
 		  on the product-serial-number contained in the voucher.</t>
-	  
-	  <t> Misbinding of pledge by a faked domain registrar is countered as 
+
+	  <t> Misbinding of pledge by a faked domain registrar is countered as
 	      described in BRSKI security considerations (section 11.4).</t>
 
-	  <t> Misuse of registrar-agent LDevID may be addressed by utilizing 
-	      short-lived certificates to be used for authenticating the 
-		  registrar-agent against the registrar. The LDevID certificate for 
-		  the registrar-agent may be provided by a prior BRSKI execution based 
-		  on an existing IDevID. Alternatively, the LDevID may be acquired  by 
-		  a service technician after authentication against the issuing CA. </t>		  
+	  <t> Misuse of registrar-agent LDevID may be addressed by utilizing
+	      short-lived certificates to be used for authenticating the
+		  registrar-agent against the registrar. The LDevID certificate for
+		  the registrar-agent may be provided by a prior BRSKI execution based
+		  on an existing IDevID. Alternatively, the LDevID may be acquired  by
+		  a service technician after authentication against the issuing CA. </t>
 	  </section>
 
     </section>
 
     <section title="Acknowledgments">
       <t> We would like to thank the various reviewers for their input, in
-          particular Brian E. Carpenter, Michael Richardson, Giorgio Romanenghi, 
-		  Oskar Camenzind, for their input and discussion on use cases and 
-		  call flows. 
+          particular Brian E. Carpenter, Michael Richardson, Giorgio Romanenghi,
+		  Oskar Camenzind, for their input and discussion on use cases and
+		  call flows.
       </t>
     </section>
   </middle>
 
   <back>
-    <references title="Normative References">  
-      <?rfc include="reference.RFC.2119" ?>        
-	  <?rfc include="reference.RFC.6762" ?>    
-      <?rfc include="reference.RFC.6763" ?>        
-	  <?rfc include="reference.RFC.7030" ?>    
-	  <?rfc include="reference.RFC.7515" ?>    
+    <references title="Normative References">
+      <?rfc include="reference.RFC.2119" ?>
+	  <?rfc include="reference.RFC.6762" ?>
+      <?rfc include="reference.RFC.6763" ?>
+	  <?rfc include="reference.RFC.7030" ?>
+	  <?rfc include="reference.RFC.7515" ?>
 	  <?rfc include="reference.RFC.8174" ?>
-      <?rfc include="reference.RFC.8366" ?>  
+      <?rfc include="reference.RFC.8366" ?>
       <?rfc include="reference.RFC.8995" ?>
-	  <?rfc include="reference.I-D.richardson-anima-jose-voucher" ?> 
-	  <?rfc include="reference.I-D.ietf-netconf-sztp-csr" ?> 
+	  <?rfc include="reference.I-D.richardson-anima-jose-voucher" ?>
+	  <?rfc include="reference.I-D.ietf-netconf-sztp-csr" ?>
     </references>
 
     <references title="Informative References">
 
 	  <reference anchor="IEC-62351-9">
 	    <front>
-	      <title>IEC 62351 - Power systems management and associated information 
-		         exchange - Data and communications security - Part 9: Cyber 
+	      <title>IEC 62351 - Power systems management and associated information
+		         exchange - Data and communications security - Part 9: Cyber
 				 security key management for power system equipment</title>
 	      <author>
 	        <organization>International Electrotechnical Commission</organization>
@@ -2453,7 +2453,7 @@ registrar-agent">
 	    <front>
 	      <title>IEEE 802.1AR Secure Device Identifier</title>
 	      <author>
-	        <organization>Institute of Electrical and Electronics 
+	        <organization>Institute of Electrical and Electronics
 			Engineers</organization>
 	      </author>
 	      <date month="June" year="2018"/>
@@ -2463,18 +2463,18 @@ registrar-agent">
 
 	  <reference anchor="ISO-IEC-15118-2">
 	    <front>
-	      <title>ISO/IEC 15118-2 Road vehicles - Vehicle-to-Grid Communication 
-		         Interface - Part 2: Network and application protocol 
+	      <title>ISO/IEC 15118-2 Road vehicles - Vehicle-to-Grid Communication
+		         Interface - Part 2: Network and application protocol
 				 requirements</title>
 	      <author>
-	        <organization>International Standardization Organization / 
+	        <organization>International Standardization Organization /
 			International Electrotechnical Commission</organization>
 	      </author>
 	      <date month="April" year="2014"/>
   	    </front>
 	    <seriesInfo name="ISO/IEC" value="15118-2 "/>
 	  </reference>
-	  
+
 	  <reference anchor="OCPP">
 	    <front>
 	      <title>Open Charge Point Protocol 2.0.1 (Draft) </title>
@@ -2494,147 +2494,147 @@ registrar-agent">
 	  <?rfc include="reference.I-D.ietf-lamps-lightweight-cmp-profile" ?>
 	  <?rfc include="reference.I-D.ietf-lamps-cmp-updates" ?>
       <?rfc include="reference.RFC.8894" ?>
-      <?rfc include="reference.I-D.selander-ace-coap-est-oscore" ?> 
-      
+      <?rfc include="reference.I-D.selander-ace-coap-est-oscore" ?>
+
     </references>
-	
+
     <section anchor="app_history" title="History of changes [RFC Editor: please delete]">
       <t> From IETF draft 01 -> IETF 02:
-          <list style="symbols"> 
-		    <t> Defined call flow and objects for interactions in UC2. Object format 
-			    based on draft for JOSE signed voucher artifacts and aligned the 
-				remaining objects with this approach in <xref target="exchanges_uc2" /> . </t>	
-		    <t> Terminology change: issue #2 pledge-agent -> registrar-agent to 
-			    better underline agent relation.</t>	
-		    <t> Terminology change: issue #3 PULL/PUSH -> pledge-initiator-mode 
-			    and pledge-responder-mode to better address the pledge operation.</t>	
-		    <t> Communication approach between pledge and registrar-agent 
-			    changed by removing TLS-PSK (former section TLS establishment) 
-				and associated references to other drafts in favor of relying on 
-				higher layer exchange of signed data objects.</t>	
-		    <t> Details on trust relationship between registrar-agent and 
+          <list style="symbols">
+		    <t> Defined call flow and objects for interactions in UC2. Object format
+			    based on draft for JOSE signed voucher artifacts and aligned the
+				remaining objects with this approach in <xref target="exchanges_uc2" /> . </t>
+		    <t> Terminology change: issue #2 pledge-agent -> registrar-agent to
+			    better underline agent relation.</t>
+		    <t> Terminology change: issue #3 PULL/PUSH -> pledge-initiator-mode
+			    and pledge-responder-mode to better address the pledge operation.</t>
+		    <t> Communication approach between pledge and registrar-agent
+			    changed by removing TLS-PSK (former section TLS establishment)
+				and associated references to other drafts in favor of relying on
+				higher layer exchange of signed data objects.</t>
+		    <t> Details on trust relationship between registrar-agent and
 			    registrar (issue #4, #5, #9) included in <xref target="uc2" />. </t>
-			<t> Recommendation regarding short-lived certificates for 
-				registrar-agent authentication towards registrar (issue #7) in 
+			<t> Recommendation regarding short-lived certificates for
+				registrar-agent authentication towards registrar (issue #7) in
 				the security considerations.</t>
-			<t> Introduction of reference to agent signing certificate using SKID 
+			<t> Introduction of reference to agent signing certificate using SKID
 			    in agent signed data (issue #11).</t>
-			<t> Enhanced objects in exchanges between pledge and registrar-agent 
+			<t> Enhanced objects in exchanges between pledge and registrar-agent
 			    to allow the registrar to verify agent-proximity to the pledge
-				(issue #1) in <xref target="exchanges_uc2" />.</t>	
-		    <t> Details on trust relationship between registrar-agent and 
-			    pledge (issue #5) included in <xref target="uc2" />. </t>	
-		    <t> Split of use case 2 call flow into sub sections in 
-			    <xref target="exchanges_uc2" />.</t>	
-			
+				(issue #1) in <xref target="exchanges_uc2" />.</t>
+		    <t> Details on trust relationship between registrar-agent and
+			    pledge (issue #5) included in <xref target="uc2" />. </t>
+		    <t> Split of use case 2 call flow into sub sections in
+			    <xref target="exchanges_uc2" />.</t>
+
 
 		  </list>
-	  </t>  
+	  </t>
 
       <t> From IETF draft 00 -> IETF 01:
-          <list style="symbols"> 
-		    <t> Update of scope in <xref target ="sup-env" /> to include in 
-				which the pledge acts as a server. This is one main motivation 
+          <list style="symbols">
+		    <t> Update of scope in <xref target ="sup-env" /> to include in
+				which the pledge acts as a server. This is one main motivation
 				for use case 2. </t>
-		    <t> Rework of use case 2 in <xref target ="uc2" /> to consider the 
-				transport between the pledge and the pledge-agent. Addressed is 
-				the TLS channel establishment between the pledge-agent and the 
+		    <t> Rework of use case 2 in <xref target ="uc2" /> to consider the
+				transport between the pledge and the pledge-agent. Addressed is
+				the TLS channel establishment between the pledge-agent and the
 				pledge as well as the endpoint definition on the pledge. </t>
 			<t> First description of exchanged object types (needs more work)</t>
-			<t> Clarification in discovery options for enrollment endpoints at 
-			    the domain registrar based on well-known endpoints in  
-				<xref target ="discovery_eo" /> do not result in additional 
-				/.well-known URIs. Update of the illustrative example. 
-				Note that the change to /brski for the voucher related endpoints 
+			<t> Clarification in discovery options for enrollment endpoints at
+			    the domain registrar based on well-known endpoints in
+				<xref target ="discovery_eo" /> do not result in additional
+				/.well-known URIs. Update of the illustrative example.
+				Note that the change to /brski for the voucher related endpoints
 				has been taken over in the BRSKI main document.</t>
-			<t> Updated references.</t>	
-			<t> Included Thomas Werner as additional author for the document. </t> 
+			<t> Updated references.</t>
+			<t> Included Thomas Werner as additional author for the document. </t>
 		  </list>
-	  </t>  
+	  </t>
       <t> From individual version 03 -> IETF draft 00:
           <list style="symbols">
-		    <t> Inclusion of discovery options of enrollment endpoints at 
-			    the domain registrar based on well-known endpoints in  
+		    <t> Inclusion of discovery options of enrollment endpoints at
+			    the domain registrar based on well-known endpoints in
 				<xref target ="discovery_eo" /> as replacement of section 5.1.3
-				in the individual draft. This is intended to support both use 
+				in the individual draft. This is intended to support both use
 				cases in the document. An illustrative example is provided. </t>
-		    <t> Missing details provided for the description and call flow in 
-			    pledge-agent use case <xref target ="uc2" />, e.g. to 
+		    <t> Missing details provided for the description and call flow in
+			    pledge-agent use case <xref target ="uc2" />, e.g. to
 				accommodate distribution of CA certificates. </t>
-		    <t> Updated CMP example in <xref target ="exist_prot" /> to use 
-			    lightweight CMP instead of CMP, as the draft already provides 
+		    <t> Updated CMP example in <xref target ="exist_prot" /> to use
+			    lightweight CMP instead of CMP, as the draft already provides
 				the necessary /.well-known endpoints.</t>
-			<t> Requirements discussion moved to separate section in 
-			    <xref target ="req-sol" />. Shortened description of proof 
+			<t> Requirements discussion moved to separate section in
+			    <xref target ="req-sol" />. Shortened description of proof
 				of identity binding and mapping to existing protocols. </t>
-			<t> Removal of copied call flows for voucher exchange and registrar 
-			    discovery flow from 
-			    <xref target="RFC8995" /> in 
-				<xref target="uc1" /> to avoid doubling or text or 
+			<t> Removal of copied call flows for voucher exchange and registrar
+			    discovery flow from
+			    <xref target="RFC8995" /> in
+				<xref target="uc1" /> to avoid doubling or text or
 				inconsistencies. </t>
-		    <t> Reworked abstract and introduction to be more crisp regarding 
-			    the targeted solution. Several structural changes in the document 
-				to have a better distinction between requirements, use case 
-				description, and solution description as separate sections. 
+		    <t> Reworked abstract and introduction to be more crisp regarding
+			    the targeted solution. Several structural changes in the document
+				to have a better distinction between requirements, use case
+				description, and solution description as separate sections.
 				History moved to appendix. </t>
 		  </list>
-	  </t>  
+	  </t>
       <t> From individual version 02 -> 03:
           <list style="symbols">
-		    <t> Update of terminology from self-contained to authenticated 
-			    self-contained object to be consistent in the wording and to 
-				underline the protection of the object with an existing 
-				credential. Note that the naming of this object	may be discussed. 
+		    <t> Update of terminology from self-contained to authenticated
+			    self-contained object to be consistent in the wording and to
+				underline the protection of the object with an existing
+				credential. Note that the naming of this object	may be discussed.
 				An alternative name may be attestation object. </t>
-		    <t> Simplification of the architecture approach for the initial use 
-			    case having an offsite PKI. </t>		    
-			<t> Introduction of a new use case utilizing authenticated 
-			    self-contain objects to onboard a pledge using a commissioning 
-				tool containing a pledge-agent. This requires additional changes 
-				in the BRSKI call flow sequence and led to changes in the 
-				introduction, the application example,and also in the 
+		    <t> Simplification of the architecture approach for the initial use
+			    case having an offsite PKI. </t>
+			<t> Introduction of a new use case utilizing authenticated
+			    self-contain objects to onboard a pledge using a commissioning
+				tool containing a pledge-agent. This requires additional changes
+				in the BRSKI call flow sequence and led to changes in the
+				introduction, the application example,and also in the
 				related BRSKI-AE call flow. </t>
-			<t> Update of provided examples of the addressing approach used in 
-			    BRSKI to allow for support of multiple enrollment protocols in 
+			<t> Update of provided examples of the addressing approach used in
+			    BRSKI to allow for support of multiple enrollment protocols in
 			    <xref target="addressing" />.  </t>
 		  </list>
 	  </t>
       <t> From individual version 01 -> 02:
           <list style="symbols">
-		    <t> Update of introduction text to clearly relate to the usage of 
+		    <t> Update of introduction text to clearly relate to the usage of
 		        IDevID and LDevID.</t>
-			<t> Definition of the addressing approach used in BRSKI to allow for 
-			    support of multiple enrollment protocols in 
+			<t> Definition of the addressing approach used in BRSKI to allow for
+			    support of multiple enrollment protocols in
 			    <xref target="addressing" />.  This section also contains a first
-			    discussion of an optional discovery mechanism to address 
-			    situations in which the registrar supports more than one enrollment 
-			    approach. Discovery should avoid that the pledge performs a trial 
+			    discussion of an optional discovery mechanism to address
+			    situations in which the registrar supports more than one enrollment
+			    approach. Discovery should avoid that the pledge performs a trial
 			    and error of enrollment protocols.</t>
-			<t> Update of description of architecture elements and 
+			<t> Update of description of architecture elements and
 			    changes to BRSKI in <xref target="architecture" />. </t>
-			<t> Enhanced consideration of existing enrollment protocols in the 
-			    context of mapping the requirements to existing solutions in 
+			<t> Enhanced consideration of existing enrollment protocols in the
+			    context of mapping the requirements to existing solutions in
 				<xref target="req-sol" /> and in <xref target="exist_prot" />. </t>
 		  </list>
 	  </t>
       <t> From individual version 00 -> 01:
           <list style="symbols">
-		    <t> Update of examples, specifically for building automation as 
-			    well as two new application use cases in 
+		    <t> Update of examples, specifically for building automation as
+			    well as two new application use cases in
 				<xref target="app-examples" />.</t>
-			<t> Deletion of asynchronous interaction with MASA to not 
-			    complicate the use case. Note that the voucher exchange can 
-				already be handled in an asynchronous manner and is therefore 
-				not considered further. This resulted in removal of the 
-				alternative path the MASA in Figure 1 and the associated 
+			<t> Deletion of asynchronous interaction with MASA to not
+			    complicate the use case. Note that the voucher exchange can
+				already be handled in an asynchronous manner and is therefore
+				not considered further. This resulted in removal of the
+				alternative path the MASA in Figure 1 and the associated
 				description in <xref target="architecture" />.  </t>
-			<t> Enhancement of description of architecture elements and 
+			<t> Enhancement of description of architecture elements and
 			    changes to BRSKI in <xref target="architecture" />. </t>
-			<t> Consideration of existing enrollment protocols in the context 
-			    of mapping the requirements to existing solutions in 
+			<t> Consideration of existing enrollment protocols in the context
+			    of mapping the requirements to existing solutions in
 				<xref target="req-sol" />. </t>
-			<t> New section starting <xref target="exist_prot" /> with the 
-			    mapping to existing enrollment protocols by collecting 
+			<t> New section starting <xref target="exist_prot" /> with the
+			    mapping to existing enrollment protocols by collecting
 				boundary conditions. </t>
 		  </list>
 	  </t>

--- a/draft-ietf-anima-brski-async-enroll.xml
+++ b/draft-ietf-anima-brski-async-enroll.xml
@@ -2411,16 +2411,16 @@ registrar-agent">
 
   <back>
     <references title="Normative References">
-      <?rfc include="reference.RFC.2119" ?>
-	  <?rfc include="reference.RFC.6762" ?>
-      <?rfc include="reference.RFC.6763" ?>
-	  <?rfc include="reference.RFC.7030" ?>
-	  <?rfc include="reference.RFC.7515" ?>
-	  <?rfc include="reference.RFC.8174" ?>
-      <?rfc include="reference.RFC.8366" ?>
-      <?rfc include="reference.RFC.8995" ?>
-	  <?rfc include="reference.I-D.richardson-anima-jose-voucher" ?>
-	  <?rfc include="reference.I-D.ietf-netconf-sztp-csr" ?>
+      <?rfc include="reference.RFC.2119.xml" ?>
+      <?rfc include="reference.RFC.6762.xml" ?>
+      <?rfc include="reference.RFC.6763.xml" ?>
+      <?rfc include="reference.RFC.7030.xml" ?>
+      <?rfc include="reference.RFC.7515.xml" ?>
+      <?rfc include="reference.RFC.8174.xml" ?>
+      <?rfc include="reference.RFC.8366.xml" ?>
+      <?rfc include="reference.RFC.8995.xml" ?>
+      <?rfc include="reference.I-D.richardson-anima-jose-voucher.xml" ?>
+      <?rfc include="reference.I-D.ietf-netconf-sztp-csr.xml" ?>
     </references>
 
     <references title="Informative References">
@@ -2485,16 +2485,16 @@ registrar-agent">
   	    </front>
 	  </reference>
 
-      <?rfc include="reference.RFC.2986" ?>
-      <?rfc include="reference.RFC.4210" ?>
-      <?rfc include="reference.RFC.4211" ?>
-      <?rfc include="reference.RFC.5272" ?>
-      <?rfc include="reference.RFC.5280" ?>
-      <?rfc include="reference.RFC.5652" ?>
-	  <?rfc include="reference.I-D.ietf-lamps-lightweight-cmp-profile" ?>
-	  <?rfc include="reference.I-D.ietf-lamps-cmp-updates" ?>
-      <?rfc include="reference.RFC.8894" ?>
-      <?rfc include="reference.I-D.selander-ace-coap-est-oscore" ?>
+      <?rfc include="reference.RFC.2986.xml" ?>
+      <?rfc include="reference.RFC.4210.xml" ?>
+      <?rfc include="reference.RFC.4211.xml" ?>
+      <?rfc include="reference.RFC.5272.xml" ?>
+      <?rfc include="reference.RFC.5280.xml" ?>
+      <?rfc include="reference.RFC.5652.xml" ?>
+      <?rfc include="reference.I-D.ietf-lamps-lightweight-cmp-profile.xml" ?>
+      <?rfc include="reference.I-D.ietf-lamps-cmp-updates.xml" ?>
+      <?rfc include="reference.RFC.8894.xml" ?>
+      <?rfc include="reference.I-D.selander-ace-coap-est-oscore.xml" ?>
 
     </references>
 


### PR DESCRIPTION
This removes trailing whitespace from lines that have it.
I suggest you set up your editor to always do that for you, as git gets annoyed with changes in trailing whitespace.
A second commit fixes the <?rfc include lines to have a trailing .xml in the file name.  This is a change in how xml2rfc works, and how the IETF references servers is setup. 